### PR TITLE
Refactor interfaces to align with backend schema

### DIFF
--- a/apps/fe-react-app/src/feature/manager/cinema-room/components/RoomListView.tsx
+++ b/apps/fe-react-app/src/feature/manager/cinema-room/components/RoomListView.tsx
@@ -81,12 +81,12 @@ const RoomCard: React.FC<RoomCardProps> = ({ room, onRoomSelect, onEditRoom, onC
           <p className="text-sm text-muted-foreground mb-3">{room.id}</p>
 
           <div className="flex gap-2">
-            <Badge variant={getRoomTypeVariant(room.type)} className="text-xs">
-              <Icon icon={getRoomTypeIcon(room.type)} className="mr-1 h-3 w-3" />
+            <Badge variant={getRoomTypeVariant(room.type ?? "")} className="text-xs">
+              <Icon icon={getRoomTypeIcon(room.type ?? "")} className="mr-1 h-3 w-3" />
               {room.type}
             </Badge>
-            <Badge variant={getRoomStatusVariant(room.status)} className="text-xs">
-              <Icon icon={getRoomStatusIcon(room.status)} className="mr-1 h-3 w-3" />
+            <Badge variant={getRoomStatusVariant(room.status ?? "")} className="text-xs">
+              <Icon icon={getRoomStatusIcon(room.status ?? "")} className="mr-1 h-3 w-3" />
               {room.status}
             </Badge>
           </div>
@@ -119,7 +119,7 @@ const RoomCard: React.FC<RoomCardProps> = ({ room, onRoomSelect, onEditRoom, onC
         <Button
           onClick={(e) => {
             e.stopPropagation();
-            onRoomSelect(room.id.toString());
+              onRoomSelect(room.id?.toString() || "");
           }}
           className="flex-1"
           size="sm"
@@ -196,12 +196,13 @@ export const RoomListView: React.FC<RoomListViewProps> = ({
   onDeleteRoom,
 }) => {
   // Filter rooms
-  const filteredRooms = rooms.filter((room) => {
-    const matchesSearch =
-      room.name.toLowerCase().includes(searchQuery.toLowerCase()) || room.id.toString().toLowerCase().includes(searchQuery.toLowerCase());
-    const matchesSort = sortBy === "all" || room.type === sortBy;
-    return matchesSearch && matchesSort;
-  });
+    const filteredRooms = rooms.filter((room) => {
+      const matchesSearch =
+        (room.name?.toLowerCase() || "").includes(searchQuery.toLowerCase()) ||
+        (room.id?.toString().toLowerCase() || "").includes(searchQuery.toLowerCase());
+      const matchesSort = sortBy === "all" || room.type === sortBy;
+      return matchesSearch && matchesSort;
+    });
 
   return (
     <Card className="shadow-lg">

--- a/apps/fe-react-app/src/feature/manager/cinema-room/components/SeatMapManagement.tsx
+++ b/apps/fe-react-app/src/feature/manager/cinema-room/components/SeatMapManagement.tsx
@@ -65,18 +65,18 @@ const SeatMapManagement: React.FC = () => {
       // Create default seats for the room
       const defaultSeats: Seat[] = [];
       // Use room dimensions directly to avoid dependency loop
-      const width = room.width;
-      const height = room.length;
+        const width = room.width ?? 0;
+        const height = room.length ?? 0;
 
       for (let row = 0; row < height; row++) {
         for (let col = 0; col < width; col++) {
           const seatRow = String.fromCharCode(65 + row); // A, B, C, etc.
           const seatColumn = (col + 1).toString(); // 1, 2, 3, etc.
 
-          const seat: Seat = {
-            id: -(Date.now() + col * 1000 + row), // Generate temporary negative ID
-            name: `${seatRow}${seatColumn}`,
-            roomId: room.id,
+            const seat: Seat = {
+              id: -(Date.now() + col * 1000 + row), // Generate temporary negative ID
+              name: `${seatRow}${seatColumn}`,
+              roomId: room.id ?? 0,
             column: seatColumn,
             row: seatRow,
             status: "AVAILABLE",
@@ -93,10 +93,10 @@ const SeatMapManagement: React.FC = () => {
         }
       }
 
-      const newSeatMap: SeatMap = {
-        gridData: defaultSeats,
-        roomId: room.id,
-      };
+        const newSeatMap: SeatMap = {
+          gridData: defaultSeats,
+          roomId: room.id ?? 0,
+        };
 
       setSeatMap(newSeatMap);
       setOriginalSeatMap(JSON.parse(JSON.stringify(newSeatMap)));
@@ -128,11 +128,11 @@ const SeatMapManagement: React.FC = () => {
   useEffect(() => {
     if (room && !roomSettingsInitialized.current) {
       // Only initialize if roomSettings hasn't been set yet
-      setRoomSettings({
-        width: room.width,
-        height: room.length,
-        name: room.name,
-      });
+        setRoomSettings({
+          width: room.width ?? 0,
+          height: room.length ?? 0,
+          name: room.name ?? "",
+        });
       roomSettingsInitialized.current = true;
     }
   }, [room]);
@@ -145,7 +145,7 @@ const SeatMapManagement: React.FC = () => {
   // Reset seat map when room dimensions change (using ref to prevent infinite loop)
   useEffect(() => {
     if (room) {
-      const currentDimensions = { width: room.width, length: room.length };
+        const currentDimensions = { width: room.width ?? 0, length: room.length ?? 0 };
 
       // Check if this is the first time setting dimensions
       if (prevRoomDimensionsRef.current === null) {
@@ -160,10 +160,10 @@ const SeatMapManagement: React.FC = () => {
       if (dimensionsChanged && seatMap && seatMap.gridData.length > 0) {
         // Room dimensions have changed, recreate seat map
         const seats = getSeatMapFromRoom(room);
-        const newSeatMap: SeatMap = {
-          gridData: seats || [],
-          roomId: room.id,
-        };
+          const newSeatMap: SeatMap = {
+            gridData: seats || [],
+            roomId: room.id ?? 0,
+          };
         setSeatMap(newSeatMap);
         setOriginalSeatMap(JSON.parse(JSON.stringify(newSeatMap)));
         toast.info("Kích thước phòng đã thay đổi. Sơ đồ ghế đã được cập nhật.");
@@ -191,7 +191,7 @@ const SeatMapManagement: React.FC = () => {
             const seat: Seat = {
               id: -(Date.now() + col * 1000 + row), // Generate temporary negative ID
               name: `${seatRow}${seatColumn}`,
-              roomId: room.id,
+              roomId: room.id ?? 0,
               column: seatColumn,
               row: seatRow,
               status: "AVAILABLE",
@@ -210,7 +210,7 @@ const SeatMapManagement: React.FC = () => {
 
         const newSeatMap: SeatMap = {
           gridData: defaultSeats,
-          roomId: room.id,
+            roomId: room.id ?? 0,
         };
 
         setSeatMap(newSeatMap);
@@ -279,11 +279,11 @@ const SeatMapManagement: React.FC = () => {
 
   const handleResetRoomSettings = () => {
     if (room) {
-      setRoomSettings({
-        width: room.width,
-        height: room.length,
-        name: room.name,
-      });
+        setRoomSettings({
+          width: room.width ?? 0,
+          height: room.length ?? 0,
+          name: room.name ?? "",
+        });
       toast.info("Đã khôi phục cài đặt phòng về giá trị ban đầu");
     }
   };
@@ -298,10 +298,10 @@ const SeatMapManagement: React.FC = () => {
         length: roomSettings.height, // Map height to length
       });
 
-      await updateRoomMutation.mutateAsync({
-        params: { path: { roomId: room.id } },
-        body: updateData,
-      });
+        await updateRoomMutation.mutateAsync({
+          params: { path: { roomId: room.id ?? 0 } },
+          body: updateData,
+        });
 
       // Refetch room data to get updated info
       await refetchRoom();
@@ -327,7 +327,7 @@ const SeatMapManagement: React.FC = () => {
         if (freshSeats.length > 0) {
           const freshSeatMap: SeatMap = {
             gridData: freshSeats,
-            roomId: freshRoom.id,
+              roomId: freshRoom.id ?? 0,
           };
 
           setSeatMap(freshSeatMap);

--- a/apps/fe-react-app/src/feature/manager/food/ComboCard.tsx
+++ b/apps/fe-react-app/src/feature/manager/food/ComboCard.tsx
@@ -2,7 +2,12 @@ import { Badge } from "@/components/Shadcn/ui/badge";
 import { Button } from "@/components/Shadcn/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/Shadcn/ui/card";
 import type { Combo } from "@/interfaces/combo.interface";
-import { formatPrice, getComboStatusLabel, useComboPrice } from "@/services/comboService";
+import {
+  formatPrice,
+  getComboStatusLabel,
+  useComboPrice,
+  type ComboStatus,
+} from "@/services/comboService";
 import { cn } from "@/utils/utils";
 import { Edit, Eye, Trash, Utensils } from "lucide-react";
 
@@ -15,7 +20,7 @@ interface ComboCardProps {
 }
 
 const ComboCard: React.FC<ComboCardProps> = ({ combo, onEdit, onDelete, onViewDetails, viewMode = "grid" }) => {
-  const { totalPrice, isLoading, error } = useComboPrice(combo.id);
+  const { totalPrice, isLoading, error } = useComboPrice(combo.id ?? 0);
 
   const getDisplayPrice = () => {
     if (isLoading) {
@@ -28,7 +33,7 @@ const ComboCard: React.FC<ComboCardProps> = ({ combo, onEdit, onDelete, onViewDe
   };
 
   const StatusBadge = () => {
-    const statusLabel = getComboStatusLabel(combo.status);
+    const statusLabel = getComboStatusLabel(combo.status as ComboStatus);
     const isAvailable = combo.status === "AVAILABLE";
 
     return (
@@ -56,7 +61,7 @@ const ComboCard: React.FC<ComboCardProps> = ({ combo, onEdit, onDelete, onViewDe
         <Button
           size="sm"
           variant="destructive"
-          onClick={() => onDelete(combo.id)}
+          onClick={() => onDelete(combo.id ?? 0)}
           className={isFullWidth ? "flex-1" : "h-8 w-8 p-0 hover:border-red-200 hover:bg-red-50 hover:text-red-600"}
         >
           <Trash className={isFullWidth ? "mr-1 h-3 w-3" : "h-4 w-4"} />

--- a/apps/fe-react-app/src/feature/manager/food/ComboDetail.tsx
+++ b/apps/fe-react-app/src/feature/manager/food/ComboDetail.tsx
@@ -3,7 +3,12 @@ import { Card, CardContent } from "@/components/Shadcn/ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/Shadcn/ui/dialog";
 import { type Combo, type ComboSnack } from "@/interfaces/combo.interface";
 import { type Snack } from "@/interfaces/snacks.interface";
-import { calculateComboPrice, formatPrice, getComboStatusLabel } from "@/services/comboService";
+import {
+  calculateComboPrice,
+  formatPrice,
+  getComboStatusLabel,
+  type ComboStatus,
+} from "@/services/comboService";
 import { Icon } from "@iconify/react";
 import { Edit, ShoppingBag, Utensils } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -83,7 +88,7 @@ const ComboDetail: React.FC<ComboDetailProps> = ({ combo, open, onClose, onDelet
   }, [combo, combo.snacks]); // Thêm combo.snacks vào dependency để cập nhật khi snacks thay đổi
 
   const totalPrice = calculateComboPrice(displayCombo);
-  const statusLabel = getComboStatusLabel(displayCombo.status);
+  const statusLabel = getComboStatusLabel(displayCombo.status as ComboStatus);
 
   const handleEditSnacks = () => {
     setEditMode(true);

--- a/apps/fe-react-app/src/feature/manager/food/ComboDetailForm.tsx
+++ b/apps/fe-react-app/src/feature/manager/food/ComboDetailForm.tsx
@@ -134,20 +134,20 @@ const ComboDetailForm: React.FC<ComboDetailFormProps> = ({ combo, onCancel, onAd
 
   const onSubmit = (values: z.infer<typeof comboSnackFormSchema>) => {
     if (selectedComboSnack && onUpdateSnack) {
-      const updatedComboSnack: ComboSnack = {
-        ...selectedComboSnack,
-        quantity: values.quantity,
-        snackSizeId: values.snackSizeId,
-        discountPercentage: values.discountPercentage,
-      };
+        const updatedComboSnack: ComboSnack = {
+          ...selectedComboSnack,
+          quantity: values.quantity,
+          snackSizeId: values.snackSizeId ?? undefined,
+          discountPercentage: values.discountPercentage ?? undefined,
+        };
       onUpdateSnack(updatedComboSnack);
     } else if (onAddSnack) {
       const selectedSnack = snacks.find((s) => s.id === values.snackId);
       if (selectedSnack) {
-        const newComboSnack: Partial<ComboSnack> = {
-          quantity: values.quantity,
-          snackSizeId: values.snackSizeId,
-          discountPercentage: values.discountPercentage,
+          const newComboSnack: Partial<ComboSnack> = {
+            quantity: values.quantity,
+            snackSizeId: values.snackSizeId ?? undefined,
+            discountPercentage: values.discountPercentage ?? undefined,
           snack: selectedSnack,
           combo,
         };

--- a/apps/fe-react-app/src/feature/manager/food/ComboDetailTable.tsx
+++ b/apps/fe-react-app/src/feature/manager/food/ComboDetailTable.tsx
@@ -145,7 +145,7 @@ const ComboDetailTable: React.FC<ComboDetailTableProps> = ({ comboSnacks, onAddN
                               <Edit className="h-3.5 w-3.5" />
                             </Button>
                             {onDeleteSnack && (
-                              <Button variant="destructive" size="sm" onClick={() => handleDeleteSnack(comboSnack.id)}>
+                              <Button variant="destructive" size="sm" onClick={() => handleDeleteSnack(comboSnack.id ?? 0)}>
                                 <MinusCircle className="h-3.5 w-3.5" />
                               </Button>
                             )}

--- a/apps/fe-react-app/src/feature/manager/food/ComboForm.tsx
+++ b/apps/fe-react-app/src/feature/manager/food/ComboForm.tsx
@@ -44,7 +44,7 @@ const ComboForm: React.FC<ComboFormProps> = ({ combo, onSubmit, onCancel }) => {
           img: combo.img,
           name: combo.name,
           description: combo.description,
-          status: combo.status,
+          status: combo.status as "AVAILABLE" | "UNAVAILABLE" | undefined,
         });
       }, 0);
     } else {

--- a/apps/fe-react-app/src/feature/manager/food/ComboManagement.tsx
+++ b/apps/fe-react-app/src/feature/manager/food/ComboManagement.tsx
@@ -37,6 +37,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import ComboDetail from "./ComboDetail";
 import ComboForm from "./ComboForm";
+import type { ComboForm as ComboFormData } from "@/interfaces/combo.interface";
 import ComboTable from "./ComboTable";
 
 // Hàm filter toàn cục với kiểm tra null/undefined
@@ -257,8 +258,8 @@ const ComboManagement: React.FC = () => {
           })) || [],
       };
 
-      setDetailsCombo(comboWithValidSnacks);
-      setSelectedComboIdForDetails(combo.id);
+        setDetailsCombo(comboWithValidSnacks);
+        setSelectedComboIdForDetails(combo.id ?? null);
       setDetailsOpen(true);
     },
     [selectedComboIdForDetails, detailsOpen],
@@ -266,17 +267,17 @@ const ComboManagement: React.FC = () => {
 
   const confirmDelete = useCallback(() => {
     if (!comboToDelete) return;
-    deleteComboMutation.mutate({
-      params: { path: { id: comboToDelete.id } },
-    });
+      deleteComboMutation.mutate({
+        params: { path: { id: comboToDelete.id ?? 0 } },
+      });
   }, [comboToDelete, deleteComboMutation]);
 
   const handleFormSubmit = useCallback(
-    (data: Omit<Combo, "id">) => {
+    (data: ComboFormData) => {
       if (selectedCombo) {
         updateComboMutation.mutate({
-          params: { path: { id: selectedCombo.id } },
-          body: transformComboToRequest({ ...selectedCombo, ...data }),
+          params: { path: { id: selectedCombo.id ?? 0 } },
+        body: transformComboToRequest({ ...selectedCombo, ...data }),
         });
       } else {
         createComboMutation.mutate({
@@ -298,7 +299,7 @@ const ComboManagement: React.FC = () => {
 
       setDetailsCombo((prev) => (prev ? { ...prev, snacks: prev.snacks.filter((s) => s.id !== comboSnackId) } : null));
       deleteComboSnackByComboAndSnackMutation.mutate({
-        params: { path: { comboId: detailsCombo.id, snackId: comboSnackToDelete.snack.id } },
+        params: { path: { comboId: detailsCombo.id ?? 0, snackId: comboSnackToDelete.snack.id } },
       });
     },
     [detailsCombo, deleteComboSnackByComboAndSnackMutation],
@@ -319,7 +320,7 @@ const ComboManagement: React.FC = () => {
 
       const requestBody = transformComboSnackToRequest(comboSnack);
       updateComboSnackMutation.mutate({
-        params: { path: { id: comboSnack.id } },
+        params: { path: { id: comboSnack.id ?? 0 } },
         body: requestBody,
       });
     },
@@ -331,18 +332,18 @@ const ComboManagement: React.FC = () => {
       if (!detailsCombo || !newComboSnack.snack?.id) return;
 
       const tempId = -Date.now();
-      const tempComboSnack: ComboSnack = {
-        id: tempId,
-        combo: detailsCombo,
-        snack: newComboSnack.snack,
-        quantity: newComboSnack.quantity ?? 1,
-        snackSizeId: newComboSnack.snackSizeId ?? null,
-        discountPercentage: newComboSnack.discountPercentage ?? 0,
-      };
+        const tempComboSnack: ComboSnack = {
+          id: tempId,
+          combo: detailsCombo,
+          snack: newComboSnack.snack,
+          quantity: newComboSnack.quantity ?? 1,
+          snackSizeId: newComboSnack.snackSizeId ?? undefined,
+          discountPercentage: newComboSnack.discountPercentage ?? 0,
+        };
 
       setDetailsCombo((prev) => (prev ? { ...prev, snacks: [...prev.snacks, tempComboSnack] } : prev));
       addSnacksToComboMutation.mutate({
-        params: { path: { comboId: detailsCombo.id } },
+        params: { path: { comboId: detailsCombo.id ?? 0 } },
         body: [{ snackId: newComboSnack.snack.id, quantity: newComboSnack.quantity ?? 1 }],
       });
     },

--- a/apps/fe-react-app/src/feature/manager/food/snack/SnackCard.tsx
+++ b/apps/fe-react-app/src/feature/manager/food/snack/SnackCard.tsx
@@ -3,7 +3,14 @@ import { Button } from "@/components/Shadcn/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/Shadcn/ui/card";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/Shadcn/ui/tooltip";
 import type { Snack } from "@/interfaces/snacks.interface";
-import { getSnackCategoryLabel, getSnackSizeLabel, getSnackStatusLabel } from "@/services/snackService";
+import {
+  getSnackCategoryLabel,
+  getSnackSizeLabel,
+  getSnackStatusLabel,
+  type SnackCategory,
+  type SnackSize,
+  type SnackStatus,
+} from "@/services/snackService";
 import { cn } from "@/utils/utils";
 import { Icon } from "@iconify/react";
 import { Edit, Trash, Utensils } from "lucide-react";
@@ -26,7 +33,7 @@ const StatusBadge = ({ snack }: { snack: Snack | null | undefined }) => {
     );
   }
 
-  const statusLabel = getSnackStatusLabel(snack.status);
+  const statusLabel = getSnackStatusLabel(snack.status as SnackStatus);
   const isAvailable = snack.status === "AVAILABLE";
 
   return (
@@ -47,7 +54,7 @@ const CategoryBadge = ({ snack }: { snack: Snack | null | undefined }) => {
     );
   }
 
-  const categoryLabel = getSnackCategoryLabel(snack.category);
+  const categoryLabel = getSnackCategoryLabel(snack.category as SnackCategory);
   const isFood = snack.category === "FOOD";
 
   return (
@@ -73,7 +80,7 @@ const SizeBadge = ({ snack }: { snack: Snack | null | undefined }) => {
     );
   }
 
-  const sizeLabel = getSnackSizeLabel(snack.size);
+  const sizeLabel = getSnackSizeLabel(snack.size as SnackSize);
   let bgClass;
 
   switch (snack.size) {
@@ -119,7 +126,7 @@ const ActionButtons = ({ snack, onEdit, onDelete, isFullWidth = false }: ActionB
       <Button
         size="sm"
         variant="destructive"
-        onClick={() => onDelete(snack.id)}
+        onClick={() => onDelete(snack.id ?? 0)}
         className={isFullWidth ? "flex-1" : "h-8 w-8 p-0 hover:border-red-200 hover:bg-red-50 hover:text-red-600"}
       >
         <Trash className={isFullWidth ? "mr-1 h-3 w-3" : "h-4 w-4"} />

--- a/apps/fe-react-app/src/feature/manager/food/snack/SnackForm.tsx
+++ b/apps/fe-react-app/src/feature/manager/food/snack/SnackForm.tsx
@@ -56,12 +56,12 @@ const SnackForm: React.FC<SnackFormProps> = ({ snack, onSubmit, onCancel }) => {
         form.reset({
           img: snack.img,
           name: snack.name,
-          category: snack.category,
-          size: snack.size,
+          category: snack.category as "DRINK" | "FOOD",
+          size: snack.size as "SMALL" | "MEDIUM" | "LARGE",
           flavor: snack.flavor,
           description: snack.description,
           price: snack.price,
-          status: snack.status,
+          status: snack.status as "AVAILABLE" | "UNAVAILABLE",
         });
       }, 0);
     } else {

--- a/apps/fe-react-app/src/feature/manager/food/snack/SnackManagement.tsx
+++ b/apps/fe-react-app/src/feature/manager/food/snack/SnackManagement.tsx
@@ -40,8 +40,8 @@ const filterByGlobalSearch = (snack: Snack, searchTerm: string): boolean => {
 
   const lowerSearchTerm = searchTerm.toLowerCase().trim();
   return (
-    snack.id.toString().includes(searchTerm) ||
-    snack.name.toLowerCase().includes(lowerSearchTerm) ||
+    snack.id?.toString().includes(searchTerm) ||
+    snack.name?.toLowerCase().includes(lowerSearchTerm) ||
     (snack.flavor?.toLowerCase() || "").includes(lowerSearchTerm) ||
     (snack.description?.toLowerCase() || "").includes(lowerSearchTerm)
   );
@@ -239,10 +239,10 @@ const SnackManagement: React.FC = () => {
         id: selectedSnack.id, // Đảm bảo id luôn tồn tại và có kiểu number
       };
 
-      updateSnackMutation.mutate({
-        params: { path: { id: selectedSnack.id } },
-        body: transformSnackToRequest(updatedSnack),
-      });
+        updateSnackMutation.mutate({
+          params: { path: { id: selectedSnack.id ?? 0 } },
+          body: transformSnackToRequest(updatedSnack),
+        });
     } else {
       // Đối với trường hợp tạo mới, không cần id (sử dụng SnackForm)
       createSnackMutation.mutate({
@@ -265,9 +265,9 @@ const SnackManagement: React.FC = () => {
 
   const handleDeleteConfirm = () => {
     if (snackToDelete) {
-      deleteSnackMutation.mutate({
-        params: { path: { id: snackToDelete.id } },
-      });
+        deleteSnackMutation.mutate({
+          params: { path: { id: snackToDelete.id ?? 0 } },
+        });
     }
   };
 

--- a/apps/fe-react-app/src/feature/manager/member/MemberDetail.tsx
+++ b/apps/fe-react-app/src/feature/manager/member/MemberDetail.tsx
@@ -64,7 +64,7 @@ const formatDateTime = (dateString?: string) => {
 const MemberDetail = ({ member, open, onClose }: MemberDetailProps) => {
   const statusDisplay = useMemo(() => {
     if (!member) return { label: "", className: "" };
-    return getUserStatusDisplay(member.status);
+    return getUserStatusDisplay(member.status ?? "ACTIVE");
   }, [member]);
 
   if (!member) {

--- a/apps/fe-react-app/src/feature/manager/member/MemberForm.tsx
+++ b/apps/fe-react-app/src/feature/manager/member/MemberForm.tsx
@@ -4,7 +4,7 @@ import { DialogFooter } from "@/components/Shadcn/ui/dialog";
 import { Input } from "@/components/Shadcn/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/Shadcn/ui/select";
 import { ROLES } from "@/interfaces/roles.interface";
-import type { USER_STATUS, User, UserRequest } from "@/interfaces/users.interface";
+import type { USER_STATUS, User, UserRequest, UserUpdate } from "@/interfaces/users.interface";
 import { Eye, EyeOff } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
@@ -100,7 +100,7 @@ const MemberForm = ({ member, onSubmit, onCancel }: MemberFormProps) => {
     }
 
     // For existing member, only send changed fields
-    const changedFields: Partial<UserRequest> = {
+    const changedFields: Partial<UserUpdate & { password?: string }> = {
       role: ROLES.MEMBER, // Always include role
     };
 

--- a/apps/fe-react-app/src/feature/manager/member/MemberManagement.tsx
+++ b/apps/fe-react-app/src/feature/manager/member/MemberManagement.tsx
@@ -100,7 +100,7 @@ const filterByDateRange = (member: User, field: string, range: { from: Date | un
 };
 
 const filterByStatus = (member: User, status: string): boolean => {
-  return member.status.toLowerCase() === status.toLowerCase();
+  return (member.status?.toLowerCase() ?? "") === status.toLowerCase();
 };
 
 const filterByGender = (member: User, gender: string): boolean => {
@@ -254,7 +254,10 @@ const MemberManagement = () => {
   const handleSubmit = (values: UserRequest) => {
     if (selectedMember) {
       const updateData: UserUpdate = transformUserUpdateRequest({ ...values, role: ROLES.MEMBER });
-      updateUserMutation.mutate({ params: { path: { userId: selectedMember.id } }, body: updateData });
+        updateUserMutation.mutate({
+          params: { path: { userId: selectedMember.id ?? "" } },
+          body: updateData,
+        });
     } else {
       const registerData: UserRequest = transformRegisterRequest({ ...values, role: ROLES.MEMBER, phone: values.phone ?? "" });
       registerMutation.mutate({ body: registerData });
@@ -268,7 +271,9 @@ const MemberManagement = () => {
 
   const handleDeleteConfirm = () => {
     if (memberToDelete) {
-      deleteUserMutation.mutate({ params: { path: { userId: memberToDelete.id } } });
+        deleteUserMutation.mutate({
+          params: { path: { userId: memberToDelete.id ?? "" } },
+        });
     }
   };
 

--- a/apps/fe-react-app/src/feature/manager/member/MemberTable.tsx
+++ b/apps/fe-react-app/src/feature/manager/member/MemberTable.tsx
@@ -134,8 +134,8 @@ const MemberTable = forwardRef<{ resetPagination: () => void }, MemberTableProps
           </TableHeader>
           <TableBody>
             {currentPageData.length > 0 ? (
-              currentPageData.map((member, index) => {
-                const statusDisplay = getUserStatusDisplay(member.status);
+                currentPageData.map((member, index) => {
+                  const statusDisplay = getUserStatusDisplay(member.status ?? "ACTIVE");
 
                 return (
                   <TableRow key={member.id}>

--- a/apps/fe-react-app/src/feature/manager/movie/settings/MovieCategoryDetail.tsx
+++ b/apps/fe-react-app/src/feature/manager/movie/settings/MovieCategoryDetail.tsx
@@ -48,7 +48,7 @@ export function MovieCategoryDetail({ isOpen, onClose, onSubmit, category, title
     onSubmit({
       ...values,
       id: category?.id,
-    });
+    } as MovieCategoryFormData);
   };
 
   return (

--- a/apps/fe-react-app/src/feature/manager/show-time/ShowtimeForm.tsx
+++ b/apps/fe-react-app/src/feature/manager/show-time/ShowtimeForm.tsx
@@ -184,7 +184,11 @@ export function ShowtimeForm({ initialData, onSuccess, onCancel }: ShowtimeFormP
 
       if (initialData) {
         // Update showtime
-        const updateData = { ...showtimeData, id: initialData.id };
+        const updateData = {
+          ...showtimeData,
+          id: initialData.id,
+          roomName: initialData.roomName,
+        };
         await updateShowtimeMutation.mutateAsync({
           params: { path: { id: initialData.id } },
           body: prepareUpdateShowtimeData(updateData),
@@ -265,8 +269,8 @@ export function ShowtimeForm({ initialData, onSuccess, onCancel }: ShowtimeFormP
                         </SelectTrigger>
                       </FormControl>
                       <SelectContent>
-                        {rooms.map((room) => (
-                          <SelectItem key={room.id} value={room.id.toString()}>
+                          {rooms.map((room) => (
+                            <SelectItem key={room.id} value={(room.id ?? "").toString()}>
                             <div className="flex items-center">
                               <Home className="mr-2 h-4 w-4" />
                               {room.name}

--- a/apps/fe-react-app/src/feature/manager/staff/StaffForm.tsx
+++ b/apps/fe-react-app/src/feature/manager/staff/StaffForm.tsx
@@ -3,7 +3,7 @@ import { DatePicker } from "@/components/Shadcn/ui/date-picker";
 import { DialogFooter } from "@/components/Shadcn/ui/dialog";
 import { Input } from "@/components/Shadcn/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/Shadcn/ui/select";
-import type { StaffRequest, StaffUser } from "@/interfaces/staff.interface";
+import type { StaffRequest, StaffUpdate, StaffUser } from "@/interfaces/staff.interface";
 import type { USER_GENDER, USER_STATUS } from "@/interfaces/users.interface";
 import { Eye, EyeOff } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -102,7 +102,7 @@ const StaffForm = ({ staff, onSubmit, onCancel }: StaffFormProps) => {
     }
 
     // For existing staff, only send changed fields
-    const changedFields: Partial<StaffRequest> = {
+    const changedFields: Partial<StaffUpdate & { password?: string }> = {
       role: "STAFF", // Always include role
     };
 

--- a/apps/fe-react-app/src/feature/manager/staff/StaffManagement.tsx
+++ b/apps/fe-react-app/src/feature/manager/staff/StaffManagement.tsx
@@ -37,8 +37,8 @@ const applyFilters = (staffs: StaffUser[], criteria: StrictFilterCriteria[], sea
   if (searchTerm) {
     const lowerSearchTerm = searchTerm.toLowerCase().trim();
     result = result.filter(
-      (staff) =>
-        staff.id.toString().includes(lowerSearchTerm) ||
+        (staff) =>
+          (staff.id?.toString() ?? "").includes(lowerSearchTerm) ||
         (staff.fullName?.toLowerCase() ?? "").includes(lowerSearchTerm) ||
         (staff.email?.toLowerCase() ?? "").includes(lowerSearchTerm) ||
         (staff.phone?.toLowerCase() ?? "").includes(lowerSearchTerm) ||
@@ -58,8 +58,11 @@ const applyFilters = (staffs: StaffUser[], criteria: StrictFilterCriteria[], sea
           const birthDate = staff.dateOfBirth ? new Date(staff.dateOfBirth) : null;
           return birthDate ? !(range.from && birthDate < range.from) && !(range.to && birthDate > range.to) : false;
         }
-        case "status":
-          return staff.status.toLowerCase() === (criterion.value as string).toLowerCase();
+          case "status":
+            return (
+              (staff.status?.toLowerCase() ?? "") ===
+              (criterion.value as string).toLowerCase()
+            );
         case "gender":
           return criterion.value === "NOT_SET" ? !staff.gender : staff.gender === criterion.value;
         default:
@@ -202,10 +205,10 @@ const StaffManagement: React.FC = () => {
 
   const handleSubmit = (staffData: StaffRequest) => {
     if (selectedStaff) {
-      updateUserMutation.mutate({
-        params: { path: { userId: selectedStaff.id } },
-        body: transformUserUpdateRequest({ ...staffData, id: selectedStaff.id, role: ROLES.STAFF }),
-      });
+        updateUserMutation.mutate({
+          params: { path: { userId: selectedStaff.id ?? "" } },
+          body: transformUserUpdateRequest({ ...staffData, id: selectedStaff.id, role: ROLES.STAFF }),
+        });
     } else {
       registerMutation.mutate({
         body: transformRegisterRequest({ ...staffData, role: ROLES.STAFF, phone: staffData.phone ?? "" }),
@@ -220,9 +223,9 @@ const StaffManagement: React.FC = () => {
 
   const handleDeleteStaff = () => {
     if (staffToDelete) {
-      deleteUserMutation.mutate({
-        params: { path: { userId: staffToDelete.id } },
-      });
+        deleteUserMutation.mutate({
+          params: { path: { userId: staffToDelete.id ?? "" } },
+        });
     }
   };
 

--- a/apps/fe-react-app/src/feature/manager/staff/StaffTable.tsx
+++ b/apps/fe-react-app/src/feature/manager/staff/StaffTable.tsx
@@ -118,7 +118,7 @@ const StaffTable = forwardRef<{ resetPagination: () => void }, StaffTableProps>(
           <TableBody>
             {currentPageData.length > 0 ? (
               currentPageData.map((staff, index) => {
-                const statusDisplay = getUserStatusDisplay(staff.status);
+                const statusDisplay = getUserStatusDisplay(staff.status ?? "ACTIVE");
 
                 return (
                   <TableRow key={staff.id}>

--- a/apps/fe-react-app/src/feature/staff/booking/StaffBookingManagement.tsx
+++ b/apps/fe-react-app/src/feature/staff/booking/StaffBookingManagement.tsx
@@ -141,10 +141,10 @@ const QuickActionButtons: React.FC<{
           break;
       }
 
-      await updateBookingMutation.mutateAsync({
-        params: { path: { id: booking.id } },
-        body: updateData,
-      });
+        await updateBookingMutation.mutateAsync({
+          params: { path: { id: booking.id ?? 0 } },
+          body: updateData,
+        });
 
       onUpdate();
       toast.success("Cập nhật thành công!");
@@ -231,10 +231,10 @@ const BookingDetailModal: React.FC<{ booking: ApiBooking; onUpdate: () => void }
 
   const handleUpdate = async () => {
     try {
-      await updateBookingMutation.mutateAsync({
-        params: { path: { id: booking.id } },
-        body: editForm,
-      });
+        await updateBookingMutation.mutateAsync({
+          params: { path: { id: booking.id ?? 0 } },
+          body: editForm,
+        });
 
       onUpdate();
       toast.success("Cập nhật booking thành công!");
@@ -352,7 +352,7 @@ const BookingDetailModal: React.FC<{ booking: ApiBooking; onUpdate: () => void }
               </div>
               <div>
                 <Label className="text-sm font-medium text-gray-500">Điểm tích lũy sử dụng</Label>
-                <p className="text-sm">{booking.loyaltyPoints || 0} điểm</p>
+                  <p className="text-sm">{booking.loyaltyPointsUsed || 0} điểm</p>
               </div>
               <div>
                 <Label className="text-sm font-medium text-gray-500">Nhân viên xử lý</Label>
@@ -484,10 +484,10 @@ const QuickStatusChange: React.FC<{
     try {
       const updateData = type === "booking" ? { status: newStatus as BookingStatus } : { paymentStatus: newStatus as PaymentStatus };
 
-      await updateBookingMutation.mutateAsync({
-        params: { path: { id: booking.id } },
-        body: updateData,
-      });
+        await updateBookingMutation.mutateAsync({
+          params: { path: { id: booking.id ?? 0 } },
+          body: updateData,
+        });
 
       onUpdate();
       toast.success(`Cập nhật ${type === "booking" ? "trạng thái booking" : "trạng thái thanh toán"} thành công!`);

--- a/apps/fe-react-app/src/feature/staff/sales/StaffTicketSales.tsx
+++ b/apps/fe-react-app/src/feature/staff/sales/StaffTicketSales.tsx
@@ -313,7 +313,7 @@ const StaffTicketSales: React.FC = () => {
     // Calculate snack cost from selected snacks
     const snackCost = Object.entries(selectedSnacks).reduce((sum, [snackId, quantity]) => {
       const snack = snacks.find((s) => s.id === parseInt(snackId));
-      return sum + (snack ? snack.price * quantity : 0);
+      return sum + (snack ? (snack.price ?? 0) * quantity : 0);
     }, 0);
 
     const subtotal = ticketCost + comboCost + snackCost;
@@ -373,7 +373,7 @@ const StaffTicketSales: React.FC = () => {
       bookingCombos: selectedCombos
         .filter(({ quantity }) => quantity > 0)
         .map(({ combo, quantity }) => ({
-          comboId: combo.id,
+          comboId: combo.id ?? 0,
           quantity,
         })),
       bookingSnacks: Object.entries(selectedSnacks)
@@ -483,7 +483,9 @@ const StaffTicketSales: React.FC = () => {
         }),
         selectedCombos: selectedCombos.reduce(
           (acc, { combo, quantity }) => {
-            acc[combo.id] = quantity;
+            if (combo.id !== undefined) {
+              acc[combo.id] = quantity;
+            }
             return acc;
           },
           {} as Record<number, number>,
@@ -504,7 +506,7 @@ const StaffTicketSales: React.FC = () => {
           }, 0),
           snackCost: Object.entries(selectedSnacks).reduce((sum, [snackId, quantity]) => {
             const snack = snacks.find((s) => s.id === parseInt(snackId));
-            return sum + (snack ? snack.price * quantity : 0);
+            return sum + (snack ? (snack.price ?? 0) * quantity : 0);
           }, 0),
           subtotal: calculateTotal() + usePoints * 1000 + (selectedPromotion ? calculateDiscount(selectedPromotion, calculateTotal()) : 0),
           pointsDiscount: usePoints * 1000,
@@ -730,7 +732,7 @@ const StaffTicketSales: React.FC = () => {
                 }, 0);
                 const snackCost = Object.entries(selectedSnacks).reduce((sum, [snackId, quantity]) => {
                   const snack = snacks.find((s) => s.id === parseInt(snackId));
-                  return sum + (snack ? snack.price * quantity : 0);
+                  return sum + (snack ? (snack.price ?? 0) * quantity : 0);
                 }, 0);
                 return ticketCost + comboCost + snackCost;
               })()}

--- a/apps/fe-react-app/src/feature/staff/sales/components/OrderSummary.tsx
+++ b/apps/fe-react-app/src/feature/staff/sales/components/OrderSummary.tsx
@@ -109,7 +109,7 @@ const OrderSummary: React.FC<OrderSummaryProps> = ({
                     <span>
                       {snack.name} x{quantity}
                     </span>
-                    <span>{(snack.price * quantity).toLocaleString("vi-VN")} VNĐ</span>
+                    <span>{((snack.price ?? 0) * quantity).toLocaleString("vi-VN")} VNĐ</span>
                   </div>
                 ) : null;
               })}
@@ -152,7 +152,7 @@ const OrderSummary: React.FC<OrderSummaryProps> = ({
                     }, 0) +
                     Object.entries(selectedSnacks).reduce((sum, [snackId, quantity]) => {
                       const snack = snacks.find((s) => s.id === parseInt(snackId));
-                      return sum + (snack ? snack.price * quantity : 0);
+                      return sum + ((snack?.price ?? 0) * quantity);
                     }, 0),
                 ),
               )}

--- a/apps/fe-react-app/src/feature/staff/sales/components/PaymentStep.tsx
+++ b/apps/fe-react-app/src/feature/staff/sales/components/PaymentStep.tsx
@@ -92,7 +92,7 @@ const PaymentStep: React.FC<PaymentStepProps> = ({
                     <span>
                       {snack.name} x{quantity}:
                     </span>
-                    <span>{(snack.price * quantity).toLocaleString("vi-VN")} VNĐ</span>
+                    <span>{((snack.price ?? 0) * quantity).toLocaleString("vi-VN")} VNĐ</span>
                   </div>
                 ) : null;
               })}

--- a/apps/fe-react-app/src/hooks/useMutationHandler.ts
+++ b/apps/fe-react-app/src/hooks/useMutationHandler.ts
@@ -1,4 +1,5 @@
-import type { CustomAPIResponse } from "@/type-from-be";
+import type { components } from "@/schema-from-be";
+type CustomAPIResponse = components["schemas"]["ApiResponseVoid"];
 import { type UseMutationResult, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 import { toast } from "sonner";
@@ -12,16 +13,9 @@ import { toast } from "sonner";
 const extractErrorMessage = <TError extends CustomAPIResponse>(error: TError | undefined, defaultMessage: string): string => {
   if (!error) return defaultMessage;
 
-  // Trường hợp 1: Có message trực tiếp
   if (error.message) {
     return error.message;
   }
-  // Trường hợp 2: Có mảng errors
-  else if (error.errors && Array.isArray(error.errors) && error.errors.length > 0) {
-    // Lấy thông báo lỗi từ result của phần tử đầu tiên trong mảng errors
-    return error.errors[0].result || defaultMessage;
-  }
-
   return defaultMessage;
 };
 

--- a/apps/fe-react-app/src/interfaces/auth.interface.ts
+++ b/apps/fe-react-app/src/interfaces/auth.interface.ts
@@ -1,4 +1,4 @@
 //để dành khi nào có user rồi áp sau
-import type { UserLoginResponse } from "./users.interface";
+import type { components } from "@/schema-from-be";
 
-export type AuthLoginData = Pick<UserLoginResponse, "token" | "roles" | "id" | "fullName">;
+export type AuthLoginData = components["schemas"]["AuthenticationResponse"];

--- a/apps/fe-react-app/src/interfaces/cinemarooms.interface.ts
+++ b/apps/fe-react-app/src/interfaces/cinemarooms.interface.ts
@@ -2,7 +2,10 @@ import type { Seat, SeatMap } from "./seat.interface";
 import type { components } from "@/schema-from-be";
 
 // Cinema room interface matching the real API response
-export type CinemaRoom = components["schemas"]["CinemaRoomResponse"] & {
+export type CinemaRoom = Omit<
+  components["schemas"]["CinemaRoomResponse"],
+  "seats"
+> & {
   seats: Seat[];
 };
 

--- a/apps/fe-react-app/src/interfaces/combo.interface.ts
+++ b/apps/fe-react-app/src/interfaces/combo.interface.ts
@@ -1,25 +1,16 @@
-import { type Snack } from "@/interfaces/snacks.interface";
+import type { Snack } from "@/interfaces/snacks.interface";
 import type { components } from "@/schema-from-be";
 
-export interface Combo {
-  id: number;
-  name: string;
-  description: string;
-  status: "AVAILABLE" | "UNAVAILABLE";
-  img: string;
+export type Combo = Omit<components["schemas"]["ComboResponse"], "snacks"> & {
   snacks: ComboSnack[];
-}
+};
 
-export interface ComboSnack {
-  id: number;
-  quantity: number;
-  snackSizeId: number | null;
-  discountPercentage: number | null;
+export type ComboSnack = components["schemas"]["ComboSnackResponse"] & {
   combo: Combo;
   snack: Snack;
-}
+};
 
-export type ComboForm = Omit<Combo, "id">;
+export type ComboForm = components["schemas"]["ComboRequest"];
 
 // API Combo interface from backend schema
 export type ApiCombo = components["schemas"]["ComboResponse"];

--- a/apps/fe-react-app/src/interfaces/movie-category.interface.ts
+++ b/apps/fe-react-app/src/interfaces/movie-category.interface.ts
@@ -1,12 +1,8 @@
-export interface MovieCategory {
-  id?: number;
-  name?: string;
-  description?: string;
-}
+import type { components } from "@/schema-from-be";
 
-export interface MovieCategoryFormData extends MovieCategory {
-  isActive?: boolean;
-}
+export type MovieCategory = components["schemas"]["MovieCategoryResponse"];
+
+export type MovieCategoryFormData = components["schemas"]["MovieCategoryRequest"];
 
 export interface MovieCategorySearchParams {
   search?: string;

--- a/apps/fe-react-app/src/interfaces/movies.interface.ts
+++ b/apps/fe-react-app/src/interfaces/movies.interface.ts
@@ -37,28 +37,11 @@ export interface Showtime {
   price: number;
 }
 
-export interface Movie {
-  id?: number;
-  name?: string;
-  ageRestrict?: number; // Required: Must be between 13-18 (backend constraint)
-  fromDate?: string;
-  toDate?: string;
-  actor?: string;
-  studio?: string;
-  director?: string;
-  duration?: number;
-  trailer?: string;
-  categories?: { id?: number; name?: string; description?: string }[]; // New categories field
-  categoryIds?: number[]; // For form submission
-  description?: string;
-  status?: string; // Changed from enum to string
-  poster?: string;
-  showtimes?: Showtime[]; // Mảng rỗng, không null
-}
+export type Movie =
+  components["schemas"]["MovieResponse"] & { categoryIds?: number[] };
 
-export interface MovieFormData extends Movie {
-  posterFile?: File;
-}
+export type MovieFormData =
+  components["schemas"]["MovieRequest"] & { posterFile?: File };
 
 export interface MovieHistory {
   receiptId: string;

--- a/apps/fe-react-app/src/interfaces/promotion.interface.ts
+++ b/apps/fe-react-app/src/interfaces/promotion.interface.ts
@@ -1,6 +1,6 @@
 import type { components } from "@/schema-from-be";
 
-export type Promotion = components["schemas"]["PromotionResponse"];
+export type Promotion = Required<components["schemas"]["PromotionResponse"]>;
 
 export interface PromotionRequest {
   id: number;

--- a/apps/fe-react-app/src/interfaces/receipt.interface.ts
+++ b/apps/fe-react-app/src/interfaces/receipt.interface.ts
@@ -1,61 +1,12 @@
-// Receipt related interfaces based on backend schema
-export interface Receipt {
-  id?: number;
-  user?: {
-    id?: string;
-    fullName?: string;
-    email?: string;
-    phone?: string;
-  };
-  bookingId?: number;
-  movieId?: number;
-  movieName?: string;
-  showtime?: string;
-  promotionName?: string;
-  roomName?: string;
-  items?: ReceiptItem[];
-  totalAmount?: number;
-  paymentMethod?: "CASH" | "ONLINE";
-  refunded?: boolean;
-  paymentReference?: string;
-  issuedAt?: string;
-  addedPoints?: number;
-  usedPoints?: number;
-  refundedPoints?: number;
-  ticketCount?: number;
-}
-
-export interface ReceiptItem {
-  id?: number;
-  receipt?: Receipt;
-  name?: string;
-  unitPrice?: number;
-  totalPrice?: number;
-  quantity?: number;
-  type?: "COMBO" | "SNACK" | "TICKET";
-}
-
-export interface ReceiptFilterRequest {
-  userId?: string;
-  fromDate?: string;
-  toDate?: string;
-  bookingId?: string;
-  movieName?: string;
-  paymentMethod?: "CASH" | "ONLINE";
-  refunded?: boolean;
-  minAmount?: number;
-  maxAmount?: number;
-}
-
-// For GET /receipt/topMovie endpoint
-export interface MovieTrendingResponse {
-  movieId?: number;
-  movieName?: string;
-  ticketCount?: number;
-  totalRevenue?: number;
-}
-
 import type { components } from "@/schema-from-be";
+
+export type Receipt = components["schemas"]["Receipt"];
+
+export type ReceiptItem = components["schemas"]["ReceiptItem"];
+
+export type ReceiptFilterRequest = components["schemas"]["ReceiptFilterRequest"];
+
+export type MovieTrendingResponse = components["schemas"]["MovieTrendingResponse"];
 
 // API Response wrappers from backend schema
 export type ApiResponseListReceipt = components["schemas"]["ApiResponseListReceipt"];

--- a/apps/fe-react-app/src/interfaces/seat.interface.ts
+++ b/apps/fe-react-app/src/interfaces/seat.interface.ts
@@ -5,10 +5,12 @@ export type SeatTypeEnum = "COUPLE" | "PATH" | "REGULAR" | "VIP" | "BLOCK";
 export type SeatBookingStatus = "AVAILABLE" | "MAINTENANCE" | "BOOKED" | "RESERVED";
 
 // API Response seat entity
-export type Seat = components["schemas"]["SeatResponse"] & {
-  selected?: boolean;
-  discarded?: boolean;
-};
+export type Seat =
+  Omit<Required<components["schemas"]["SeatResponse"]>, "linkSeatId"> & {
+    linkSeatId?: number | null;
+    selected?: boolean;
+    discarded?: boolean;
+  };
 
 export type SeatType = components["schemas"]["SeatTypeResponse"];
 

--- a/apps/fe-react-app/src/interfaces/showtime.interface.ts
+++ b/apps/fe-react-app/src/interfaces/showtime.interface.ts
@@ -1,11 +1,8 @@
-export interface Showtime {
-  id: number;
-  movieId: number;
-  roomId: number;
-  roomName?: string;
-  showDateTime: string;
-  endDateTime: string;
-  status: string;
-}
+import type { components } from "@/schema-from-be";
 
-export type ShowtimeFormData = Omit<Showtime, "id">;
+export type Showtime = Required<components["schemas"]["ShowtimeResponse"]>;
+
+export type ShowtimeFormData =
+  Required<components["schemas"]["ShowtimeRequest"]> & {
+    status?: string;
+  };

--- a/apps/fe-react-app/src/interfaces/snacks.interface.ts
+++ b/apps/fe-react-app/src/interfaces/snacks.interface.ts
@@ -1,18 +1,8 @@
-export interface Snack {
-  id: number;
-  category: "DRINK" | "FOOD";
-  name: string;
-  size: "SMALL" | "MEDIUM" | "LARGE";
-  flavor: string;
-  price: number;
-  description: string;
-  img: string;
-  status: "AVAILABLE" | "UNAVAILABLE";
-}
-
-export type SnackForm = Omit<Snack, "id">;
-
 import type { components } from "@/schema-from-be";
+
+export type Snack = components["schemas"]["SnackResponse"];
+
+export type SnackForm = components["schemas"]["SnackRequest"];
 
 // API Snack interface from backend schema
 export type ApiSnack = components["schemas"]["SnackResponse"];

--- a/apps/fe-react-app/src/interfaces/users.interface.ts
+++ b/apps/fe-react-app/src/interfaces/users.interface.ts
@@ -1,45 +1,15 @@
 import { type ROLE_TYPE } from "./roles.interface.ts";
+import type { components } from "@/schema-from-be";
 
 export type USER_STATUS = "ACTIVE" | "BAN";
 export type USER_GENDER = "MALE" | "FEMALE" | "OTHER";
 
 // Interface phù hợp với schema của BE - API User interface (from OpenAPI schema)
-export interface User {
-  id: string;
-  email: string;
-  fullName: string;
-  phone: string;
-  address?: string;
-  avatar?: string;
-  role: string;
-  status: string;
-  dateOfBirth?: string;
-  gender?: "MALE" | "FEMALE" | "OTHER";
-}
+export type User = components["schemas"]["UserResponse"];
 
-export type UserRequest = {
-  email: string;
-  fullName: string;
-  password: string;
-  phone?: string;
-  role?: string;
-  dateOfBirth?: string;
-  gender?: USER_GENDER;
-  address?: string;
-  status?: USER_STATUS;
-  loyaltyPoint?: number;
-};
+export type UserRequest = components["schemas"]["UserRequest"];
 
-export type UserUpdate = {
-  fullName?: string;
-  phone?: string;
-  address?: string;
-  avatar?: string;
-  role?: string;
-  status?: string;
-  gender?: USER_GENDER;
-  dateOfBirth?: string;
-};
+export type UserUpdate = components["schemas"]["UserUpdate"];
 
 // Interface cho phản hồi từ API Authentication
 export interface AuthenticationResponse {
@@ -161,7 +131,6 @@ export type UserLoginResponse = {
 };
 
 // API User interface (from OpenAPI schema)
-import type { components } from "@/schema-from-be";
 
 export type ApiUser = components["schemas"]["UserResponse"];
 

--- a/apps/fe-react-app/src/layouts/user/components/Header/components/AuthSection.tsx
+++ b/apps/fe-react-app/src/layouts/user/components/Header/components/AuthSection.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/Shadcn/ui/dropdown-menu";
 import { useAuth } from "@/hooks/useAuth";
+import type { ROLE_TYPE } from "@/interfaces/roles.interface";
 import { ROUTES } from "@/routes/route.constants";
 import { useGetUserById } from "@/services/userService";
 import { getCookie } from "@/utils/cookie.utils";
@@ -35,12 +36,17 @@ const AuthSection = ({ className = "header-actions", loginText = "Login", logout
   const isAuthenticated = isLoggedIn || hasRoles;
 
   // Parse user roles for dropdown menu items
-  const roles = user?.roles || [];
+  const roles: ROLE_TYPE[] = [];
+  if (Array.isArray(user?.roles)) {
+    roles.push(...user.roles);
+  } else if (typeof user?.roles === "string") {
+    roles.push(user.roles as ROLE_TYPE);
+  }
   if (userRoles && typeof userRoles === "string") {
     try {
       const parsedRoles = JSON.parse(userRoles);
       if (Array.isArray(parsedRoles)) {
-        roles.push(...parsedRoles);
+        roles.push(...(parsedRoles as ROLE_TYPE[]));
       }
     } catch {
       // Ignore parsing errors

--- a/apps/fe-react-app/src/services/cinemaRoomService.ts
+++ b/apps/fe-react-app/src/services/cinemaRoomService.ts
@@ -73,6 +73,7 @@ export const transformSeatResponse = (seatResponse: SeatResponse): Seat => {
           seatCount: 1,
         },
     discarded: seatResponse.discarded ?? false,
+    linkSeatId: seatResponse.linkSeatId ?? null,
   };
 };
 
@@ -86,7 +87,9 @@ export const transformCinemaRoomResponse = (roomResponse: CinemaRoomResponse): C
     status: roomResponse.status as CinemaRoomStatus,
     width: roomResponse.width ?? 0,
     length: roomResponse.length ?? 0,
-    seats: roomResponse.seats ? roomResponse.seats.map(transformSeatResponse) : [],
+    seats: roomResponse.seats
+      ? (roomResponse.seats.map(transformSeatResponse) as Seat[])
+      : [],
   };
 };
 
@@ -142,7 +145,7 @@ export const updateSeatStatus = (seat: Seat, newStatus: SeatStatus): SeatRequest
 export const convertToRoomWithSeatMap = (room: CinemaRoom): CinemaRoomWithSeatMap => {
   const seatMap: SeatMap = {
     gridData: room.seats,
-    roomId: room.id,
+    roomId: room.id ?? 0,
   };
 
   return {

--- a/apps/fe-react-app/src/services/promotionService.ts
+++ b/apps/fe-react-app/src/services/promotionService.ts
@@ -158,8 +158,8 @@ export const isPromotionActive = (promotion: Promotion): boolean => {
   if (promotion.status !== "ACTIVE") return false;
 
   const now = new Date();
-  const startTime = new Date(promotion.startTime);
-  const endTime = new Date(promotion.endTime);
+  const startTime = new Date(promotion.startTime ?? "");
+  const endTime = new Date(promotion.endTime ?? "");
 
   return now >= startTime && now <= endTime;
 };
@@ -182,17 +182,17 @@ export const formatPromotionDate = (dateString: string): string => {
  */
 export const calculateDiscount = (promotion: Promotion, purchaseAmount: number): number => {
   // Return 0 if the promotion is not active or purchase amount is below minimum
-  if (!isPromotionActive(promotion) || purchaseAmount < promotion.minPurchase) {
+  if (!isPromotionActive(promotion) || purchaseAmount < (promotion.minPurchase ?? 0)) {
     return 0;
   }
 
   if (promotion.type === "PERCENTAGE") {
     // Cap the percentage at 100%
-    const percentage = Math.min(promotion.discountValue, 100);
+    const percentage = Math.min(promotion.discountValue ?? 0, 100);
     return (purchaseAmount * percentage) / 100;
   } else if (promotion.type === "AMOUNT") {
     // Fixed amount can't be more than the purchase amount
-    return Math.min(promotion.discountValue, purchaseAmount);
+    return Math.min(promotion.discountValue ?? 0, purchaseAmount);
   }
 
   // For FREE_ITEM or unknown types, no calculation needed

--- a/apps/fe-react-app/src/services/showtimeService.ts
+++ b/apps/fe-react-app/src/services/showtimeService.ts
@@ -54,7 +54,7 @@ export const transformShowtimeResponse = (showtimeResponse: ShowtimeResponse): S
     id: showtimeResponse.id ?? 0,
     movieId: showtimeResponse.movieId ?? 0,
     roomId: showtimeResponse.roomId ?? 0,
-    roomName: showtimeResponse.roomName,
+    roomName: showtimeResponse.roomName ?? "",
     showDateTime: showtimeResponse.showDateTime ?? "",
     endDateTime: showtimeResponse.endDateTime ?? "",
     status: showtimeResponse.status ?? "SCHEDULE",
@@ -81,6 +81,6 @@ export const prepareCreateShowtimeData = (data: ShowtimeFormData) => {
   return transformShowtimeToRequest(data);
 };
 
-export const prepareUpdateShowtimeData = (data: Showtime) => {
+export const prepareUpdateShowtimeData = (data: ShowtimeFormData | Showtime) => {
   return transformShowtimeToRequest(data);
 };

--- a/apps/fe-react-app/src/services/snackService.ts
+++ b/apps/fe-react-app/src/services/snackService.ts
@@ -4,9 +4,9 @@ type SnackResponse = components["schemas"]["SnackResponse"];
 import { $api } from "@/utils/api";
 
 // Type aliases for union types
-type SnackCategory = "DRINK" | "FOOD";
-type SnackSize = "SMALL" | "MEDIUM" | "LARGE";
-type SnackStatus = "AVAILABLE" | "UNAVAILABLE";
+export type SnackCategory = "DRINK" | "FOOD";
+export type SnackSize = "SMALL" | "MEDIUM" | "LARGE";
+export type SnackStatus = "AVAILABLE" | "UNAVAILABLE";
 
 // React Query hooks for snack operations
 export const useSnacks = () => {


### PR DESCRIPTION
## Summary
- reference backend types across more interface files
- adjust auth header roles parsing
- update service transforms for optional fields
- handle undefined values in order summaries

## Testing
- `pnpm --filter fe-react-app build` *(fails: type errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_6877dec295388331b958c790867377e8