### PR TITLE
Fix combo price showing zero

### DIFF
--- a/apps/fe-react-app/src/feature/booking/components/ComboItem/ComboItem.tsx
+++ b/apps/fe-react-app/src/feature/booking/components/ComboItem/ComboItem.tsx
@@ -11,7 +11,7 @@ const ComboItem: React.FC<ComboItemProps> = ({ combo, quantity, onQuantityChange
   // Calculate total price from snacks
   const totalPrice = combo.snacks.reduce((total, comboSnack) => {
     const price = comboSnack.snack.price ?? 0;
-    const qty = comboSnack.quantity ?? 1;
+    const qty = comboSnack.quantity && comboSnack.quantity > 0 ? comboSnack.quantity : 1;
     return total + price * qty;
   }, 0);
 

--- a/apps/fe-react-app/src/services/comboService.ts
+++ b/apps/fe-react-app/src/services/comboService.ts
@@ -139,7 +139,9 @@ export const transformComboResponse = (comboResponse: ComboResponse): Combo => {
     transformedSnacks = comboResponse.snacks.map((snackData) => {
       return {
         id: Number(snackData.id ?? 0),
-        quantity: 0, // Will be updated with correct quantity from combo-snacks API
+        // Quantity information isn't provided by the `combos` endpoint.
+        // Default to 1 so price calculations don't result in 0.
+        quantity: 1,
         snackSizeId: undefined,
         discountPercentage: undefined,
         combo: {


### PR DESCRIPTION
## Summary
- default combo snack quantity to 1 when fetched from backend
- guard against zero quantity when displaying combo price
- run lint and build

## Testing
- `pnpm --filter fe-react-app lint`
- `pnpm --filter fe-react-app build`


------
https://chatgpt.com/codex/tasks/task_e_68780b2642248331856031328b3f619d