### PR TITLE
Add banner support in movie admin

### DIFF
--- a/apps/fe-react-app/src/feature/manager/movie/MovieDetail.tsx
+++ b/apps/fe-react-app/src/feature/manager/movie/MovieDetail.tsx
@@ -37,6 +37,8 @@ const formSchema = z.object({
   status: z.string().optional(),
   poster: z.string().optional(),
   posterFile: z.any().optional(),
+  banner: z.string().optional(),
+  bannerFile: z.any().optional(),
 });
 
 const MovieDetail = ({ movie, onSubmit, onCancel }: MovieDetailProps) => {
@@ -65,6 +67,7 @@ const MovieDetail = ({ movie, onSubmit, onCancel }: MovieDetailProps) => {
       description: "",
       status: MovieStatus.ACTIVE,
       poster: "",
+      banner: "",
     },
   });
 
@@ -84,10 +87,12 @@ const MovieDetail = ({ movie, onSubmit, onCancel }: MovieDetailProps) => {
         description: movie.description ?? "",
         status: movie.status ?? MovieStatus.ACTIVE,
         poster: movie.poster ?? "",
+        banner: movie.banner ?? "",
       });
     } else {
       // For new movie creation, set default poster text
       form.setValue("poster", "");
+      form.setValue("banner", "");
     }
   }, [movie, form]);
 
@@ -105,15 +110,28 @@ const MovieDetail = ({ movie, onSubmit, onCancel }: MovieDetailProps) => {
     form.setValue("posterFile", null); // Reset posterFile if URL is used
   };
 
+  const handleBannerChange = (imageIdOrUrl: string) => {
+    form.setValue("banner", imageIdOrUrl);
+    form.setValue("bannerFile", null);
+  };
+
   const handleImageClear = () => {
     form.setValue("poster", "");
     form.setValue("posterFile", null);
+  };
+
+  const handleBannerClear = () => {
+    form.setValue("banner", "");
+    form.setValue("bannerFile", null);
   };
 
   const handleFormSubmit = (values: z.infer<typeof formSchema>) => {
     // If no poster is provided or it's empty, set default text
     if (!values.poster || values.poster.trim() === "") {
       values.poster = "";
+    }
+    if (!values.banner || values.banner.trim() === "") {
+      values.banner = "";
     }
     onSubmit(values as MovieFormData);
   };
@@ -348,7 +366,7 @@ const MovieDetail = ({ movie, onSubmit, onCancel }: MovieDetailProps) => {
           )}
         />
 
-        {/* Row 7: Movie Poster và Trailer */}
+        {/* Row 7: Movie Poster và Banner */}
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <div className="space-y-2">
             <FormLabel>Movie Poster</FormLabel>
@@ -363,20 +381,34 @@ const MovieDetail = ({ movie, onSubmit, onCancel }: MovieDetailProps) => {
             />
           </div>
 
-          <FormField
-            control={form.control}
-            name="trailer"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Trailer URL</FormLabel>
-                <FormControl>
-                  <Input placeholder="Enter trailer URL (YouTube, etc.)" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+          <div className="space-y-2">
+            <FormLabel>Movie Banner</FormLabel>
+            <ImageUpload
+              currentImage={form.watch("banner") || ""}
+              onImageChange={handleBannerChange}
+              onImageClear={handleBannerClear}
+              previewSize="md"
+              preserveAspectRatio={true}
+              maxPreviewHeight={200}
+              layout="horizontal"
+            />
+          </div>
         </div>
+
+        {/* Row 8: Trailer URL */}
+        <FormField
+          control={form.control}
+          name="trailer"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Trailer URL</FormLabel>
+              <FormControl>
+                <Input placeholder="Enter trailer URL (YouTube, etc.)" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <div className="flex justify-end space-x-2 pt-4">
           <Button variant="outline" onClick={onCancel}>

--- a/apps/fe-react-app/src/feature/manager/movie/MovieViewDialog.tsx
+++ b/apps/fe-react-app/src/feature/manager/movie/MovieViewDialog.tsx
@@ -69,12 +69,18 @@ export function MovieViewDialog({ movie, isOpen, onClose }: MovieViewDialogProps
             </div>
           </div>
           <div className="space-y-4">
-            {movie.poster && (
-              <div>
-                <h3 className="mb-2 font-semibold">Poster</h3>
-                <img src={movie.poster} alt={movie.name} className="h-auto max-w-full rounded" />
-              </div>
-            )}
+          {movie.poster && (
+            <div>
+              <h3 className="mb-2 font-semibold">Poster</h3>
+              <img src={movie.poster} alt={movie.name} className="h-auto max-w-full rounded" />
+            </div>
+          )}
+          {movie.banner && (
+            <div>
+              <h3 className="mb-2 font-semibold">Banner</h3>
+              <img src={movie.banner} alt={movie.name} className="h-auto max-w-full rounded" />
+            </div>
+          )}
             <div>
               <h3 className="mb-2 font-semibold">Description</h3>
               <p className="text-gray-700">{movie.description ?? "No description available"}</p>

--- a/apps/fe-react-app/src/interfaces/movies.interface.ts
+++ b/apps/fe-react-app/src/interfaces/movies.interface.ts
@@ -39,7 +39,11 @@ export interface Showtime {
 
 export type Movie = components["schemas"]["MovieResponse"] & { categoryIds?: number[] };
 
-export type MovieFormData = components["schemas"]["MovieRequest"] & { posterFile?: File };
+export type MovieFormData =
+  components["schemas"]["MovieRequest"] & {
+    posterFile?: File;
+    bannerFile?: File;
+  };
 
 export interface MovieHistory {
   receiptId: string;

--- a/apps/fe-react-app/src/services/movieService.ts
+++ b/apps/fe-react-app/src/services/movieService.ts
@@ -76,6 +76,7 @@ export const transformMovieResponse = (movieResponse: MovieResponse): Movie => {
     description: movieResponse.description,
     status: movieResponse.status,
     poster: movieResponse.poster,
+    banner: movieResponse.banner,
     // Trả về mảng rỗng thay vì null cho showtimes (backend structure mismatch)
     showtimes: [],
   };
@@ -101,6 +102,7 @@ export const transformMovieToRequest = (movie: Movie) => {
     description: movie.description ?? "",
     status: movie.status ?? "ACTIVE", // Use string status
     poster: movie.poster ?? "",
+    banner: movie.banner ?? "",
   };
 };
 


### PR DESCRIPTION
## Summary
- add `bannerFile` to `MovieFormData`
- include `banner` field in movie transform utilities
- allow admin to upload movie banner in the movie form
- display banner in movie view dialog

## Testing
- `pnpm --filter fe-react-app build`
- `pnpm --filter fe-react-app lint`

------
https://chatgpt.com/codex/tasks/task_e_68780adcbcf08331a31929fde27c37ff