### PR TITLE
Update seat route for new BE API

### DIFF
--- a/apps/fe-react-app/src/pages/store/MovieSelection.tsx
+++ b/apps/fe-react-app/src/pages/store/MovieSelection.tsx
@@ -132,7 +132,7 @@ function MovieSelection() {
             const showDate = new Date(newShowtime.showDateTime);
             const endDate = new Date(newShowtime.endDateTime);
 
-            const seatsResponse = await fetchClient.GET("/showtimes/seats/{showtimeId}", {
+            const seatsResponse = await fetchClient.GET("/seats/showtime/{showtimeId}", {
               params: { path: { showtimeId: newShowtime.id } },
             });
             const seats = seatsResponse.data?.result ?? [];

--- a/apps/fe-react-app/src/services/showtimeService.ts
+++ b/apps/fe-react-app/src/services/showtimeService.ts
@@ -26,12 +26,8 @@ export const queryShowtimesByRoom = (roomId: number) => {
   });
 };
 
-export const queryShowtimeSearch = () => {
-  return $api.useQuery("get", "/showtimes/search");
-};
-
 export const queryShowtimeSeats = (showtimeId: number) => {
-  return $api.useQuery("get", "/showtimes/seats/{showtimeId}", {
+  return $api.useQuery("get", "/seats/showtime/{showtimeId}", {
     params: { path: { showtimeId } },
   });
 };


### PR DESCRIPTION
## Summary
- fix seat endpoint path in `queryShowtimeSeats`
- update MovieSelection seat fetch path
- remove unused `queryShowtimeSearch`

## Testing
- `pnpm --filter fe-react-app build`

------
https://chatgpt.com/codex/tasks/task_e_687864ab7988833180157333581b4c47