### PR TITLE
Implement homepage hero demo

### DIFF
--- a/apps/fe-react-app/src/components/shared/Test.tsx
+++ b/apps/fe-react-app/src/components/shared/Test.tsx
@@ -1,22 +1,38 @@
+import FCinemaLogo from "@/assets/FCinema_Logo.webp";
+import OppenheimerBackdrop from "@/assets/oppenheimer-backdrops.webp";
+import {
+  Calendar,
+  Clock,
+  Grid3x3,
+  Search,
+  Star,
+} from "lucide-react";
+
 function BlurHeader() {
   return (
-    <header className="sticky top-0 z-20 mx-auto flex w-full items-center justify-between p-5 sm:px-10">
-      <div className="pointer-events-none absolute inset-0 z-[1] h-[20vh] backdrop-blur-[0.0625px] [mask-image:linear-gradient(0deg,transparent_0%,#000_12.5%,#000_25%,transparent_37.5%)]"></div>
-      <div className="pointer-events-none absolute inset-0 z-[2] h-[20vh] backdrop-blur-[0.125px] [mask-image:linear-gradient(0deg,transparent_12.5%,#000_25%,#000_37.5%,transparent_50%)]"></div>
-      <div className="pointer-events-none absolute inset-0 z-[3] h-[20vh] backdrop-blur-[0.25px] [mask-image:linear-gradient(0deg,transparent_25%,#000_37.5%,#000_50%,transparent_62.5%)]"></div>
-      <div className="pointer-events-none absolute inset-0 z-[4] h-[20vh] backdrop-blur-[0.5px] [mask-image:linear-gradient(0deg,transparent_37.5%,#000_50%,#000_62.5%,transparent_75%)]"></div>
-      <div className="pointer-events-none absolute inset-0 z-[5] h-[20vh] backdrop-blur-[1px] [mask-image:linear-gradient(0deg,transparent_50%,#000_62.5%,#000_75%,transparent_87.5%)]"></div>
-      <div className="pointer-events-none absolute inset-0 z-[6] h-[20vh] backdrop-blur-[2px] [mask-image:linear-gradient(0deg,transparent_62.5%,#000_75%,#000_87.5%,transparent_100%)]"></div>
-      <div className="pointer-events-none absolute inset-0 z-[7] h-[20vh] backdrop-blur-[4px] [mask-image:linear-gradient(0deg,transparent_75%,#000_87.5%,#000_100%,transparent_112.5%)]"></div>
-      <div className="mx-auto flex w-full max-w-5xl items-center justify-between">
-        <a className="z-[10]" href="/">
-          Magicui
-        </a>
-        <div className="z-[10]">
-          <a href="#" className="">
-            Get Started
-          </a>
+    <header className="sticky top-0 z-20 w-full">
+      <div className="pointer-events-none absolute inset-0 z-[1] h-[20vh] backdrop-blur-[0.0625px] [mask-image:linear-gradient(0deg,transparent_0%,#000_12.5%,#000_25%,transparent_37.5%)]" />
+      <div className="pointer-events-none absolute inset-0 z-[2] h-[20vh] backdrop-blur-[0.125px] [mask-image:linear-gradient(0deg,transparent_12.5%,#000_25%,#000_37.5%,transparent_50%)]" />
+      <div className="pointer-events-none absolute inset-0 z-[3] h-[20vh] backdrop-blur-[0.25px] [mask-image:linear-gradient(0deg,transparent_25%,#000_37.5%,#000_50%,transparent_62.5%)]" />
+      <div className="pointer-events-none absolute inset-0 z-[4] h-[20vh] backdrop-blur-[0.5px] [mask-image:linear-gradient(0deg,transparent_37.5%,#000_50%,#000_62.5%,transparent_75%)]" />
+      <div className="pointer-events-none absolute inset-0 z-[5] h-[20vh] backdrop-blur-[1px] [mask-image:linear-gradient(0deg,transparent_50%,#000_62.5%,#000_75%,transparent_87.5%)]" />
+      <div className="pointer-events-none absolute inset-0 z-[6] h-[20vh] backdrop-blur-[2px] [mask-image:linear-gradient(0deg,transparent_62.5%,#000_75%,#000_87.5%,transparent_100%)]" />
+      <div className="pointer-events-none absolute inset-0 z-[7] h-[20vh] backdrop-blur-[4px] [mask-image:linear-gradient(0deg,transparent_75%,#000_87.5%,#000_100%,transparent_112.5%)]" />
+      <div className="relative grid h-16 grid-cols-12 items-center text-white">
+        <div className="col-span-2 flex items-center gap-2 pl-8">
+          <img src={FCinemaLogo} alt="Cinemagic" className="size-6" />
+          <span className="font-semibold">Cinemagic</span>
         </div>
+        <Search
+          aria-label="Search"
+          className="col-start-7 mx-auto h-6 w-6 cursor-pointer"
+        />
+        <nav className="col-start-8 col-span-3 flex items-center justify-center gap-10 text-sm font-medium uppercase">
+          <a href="#">HOME</a>
+          <a href="#">MOVIE</a>
+          <a href="#">TV SHOW</a>
+        </nav>
+        <Grid3x3 className="col-start-12 justify-self-end h-6 w-6 pr-8 cursor-pointer" />
       </div>
     </header>
   );
@@ -24,16 +40,74 @@ function BlurHeader() {
 
 export function Test() {
   return (
-    <div className="relative h-[50vh] w-full overflow-y-auto">
+    <div className="relative h-screen w-full overflow-hidden text-white">
       <BlurHeader />
-      <div className="w-full bg-yellow-200">
-        <div className="mx-auto flex h-[100vh] w-full max-w-3xl flex-col items-center justify-center gap-y-5 bg-red-400">
-          <img className="h-20 w-20" src="/android-chrome-512x512.png" alt="MagicUI Logo" />
-          <h1 className="text-balance text-center text-4xl font-bold">UI library for Design Engineers</h1>
-          <p className="text-balance text-center">
-            50+ open-source animated components built with React, Typescript, Tailwind CSS, and Framer Motion. Save thousands of hours, create a
-            beautiful landing page, and convert your visitors into customers.
-          </p>
+      <div className="relative h-[calc(100vh-64px)] w-full">
+        <img
+          src={OppenheimerBackdrop}
+          alt="Oppenheimer backdrop"
+          className="absolute inset-0 h-full w-full object-cover"
+        />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(0,0,0,0.45),transparent)]" />
+        <div className="relative z-10 grid h-full grid-cols-12 px-8">
+          <div className="col-start-2 col-span-5 self-start pt-[35vh]">
+            <h1 className="font-semibold text-[clamp(3rem,6vw,6rem)] leading-none">Oppenheimer</h1>
+            <div className="mt-4 flex flex-wrap items-center gap-x-2 text-[15px] text-[#E0E0E0]">
+              <span>Biography, Drama, History</span>
+              <span className="mx-2">•</span>
+              <Calendar className="h-4 w-4" />
+              <span>2023</span>
+              <span className="mx-2">•</span>
+              <Clock className="h-4 w-4" />
+              <span>3h 1m</span>
+            </div>
+            <div className="mt-2 flex items-center gap-2">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Star
+                  key={i}
+                  className="h-5 w-5"
+                  fill={i < 4 ? "#FFD400" : "none"}
+                  color={i < 4 ? "#FFD400" : "#4C4C4C"}
+                />
+              ))}
+              <span className="ml-4 rounded-full border border-[#E0E0E0] px-2 py-0.5 text-[12px] text-[#E0E0E0]">PG-13</span>
+            </div>
+            <div className="mt-6 flex gap-3">
+              <button className="h-11 w-38 rounded bg-[#FFD400] px-4 text-sm font-medium text-[#0C0B0E]">
+                Book Tickets
+              </button>
+              <button className="h-11 w-38 rounded border border-[#FFD400] px-4 text-sm font-medium text-[#FFD400]">
+                Review
+              </button>
+              <button className="h-11 w-38 rounded border border-[#A0A0A0] px-4 text-sm font-medium text-[#A0A0A0]">
+                More
+              </button>
+            </div>
+          </div>
+          <div className="col-start-7 col-span-2 flex items-center justify-center pt-[35vh]">
+            <div className="flex gap-3">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <span
+                  key={i}
+                  className={
+                    i === 0
+                      ? "size-2.5 rounded-full bg-white"
+                      : "size-2.5 rounded-full bg-white/35"
+                  }
+                />
+              ))}
+            </div>
+          </div>
+          <div className="col-start-9 col-span-3 pt-[35vh]">
+            <p className="leading-6 text-[#E0E0E0]">
+              Christopher Nolan : <span className="text-[#FFD400]">Director</span>
+              <br />
+              Cillian Murphy, Emily Blunt, Matt Damon : <span className="text-[#FFD400]">Stars</span>
+            </p>
+            <p className="mt-4 max-w-[32ch] text-sm text-[#E0E0E0]">
+              The story of American scientist, J. Robert Oppenheimer, and his role in the development of the atomic bomb.
+            </p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- redesign `Test` component as the homepage hero banner
- keep the stacked blur header effect and add navbar items
- display Oppenheimer backdrop with movie metadata and CTA buttons

## Testing
- `pnpm --filter fe-react-app lint`
- `pnpm --filter fe-react-app build`


------
https://chatgpt.com/codex/tasks/task_e_687bd053573c83318c37ae7f9d01697c