### PR TITLE
Add Booking API interface

### DIFF
--- a/apps/fe-react-app/src/interfaces/booking.api.interface.ts
+++ b/apps/fe-react-app/src/interfaces/booking.api.interface.ts
@@ -1,0 +1,8 @@
+import type { components } from "@/schema-from-be";
+
+export type BookingApi = components["schemas"]["BookingResponse"];
+export type BookingComboApi = components["schemas"]["BookingComboResponse"];
+export type BookingSnackApi = components["schemas"]["BookingSnackResponse"];
+export type BookingRequestApi = components["schemas"]["BookingRequest"];
+export type BookingUpdateApi = components["schemas"]["BookingUpdate"];
+

--- a/apps/fe-react-app/src/interfaces/index.interface.ts
+++ b/apps/fe-react-app/src/interfaces/index.interface.ts
@@ -1,5 +1,6 @@
 export * from "./auth.interface";
 export * from "./booking.interface";
+export * from "./booking.api.interface";
 export * from "./cinemarooms.interface";
 export * from "./combo.interface";
 export * from "./member.interface";


### PR DESCRIPTION
## Summary
- add a new interface `booking.api.interface.ts` to provide type aliases to backend schemas
- re-export booking API types in `index.interface.ts`

## Testing
- `pnpm --filter fe-react-app build`

------
https://chatgpt.com/codex/tasks/task_e_687da25bf39483319712ccc979b243b4