### PR TITLE
Refactor booking types to use backend schema

### DIFF
--- a/apps/fe-react-app/src/feature/booking/BookingSuccessPage.tsx
+++ b/apps/fe-react-app/src/feature/booking/BookingSuccessPage.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/Shadcn/ui/button";
-import { useBooking, transformBookingResponse } from "@/services/bookingService";
+import { useBooking } from "@/services/bookingService";
 import { useCinemaRoom } from "@/services/cinemaRoomService";
 import type {
   ApiBooking,
@@ -72,7 +72,7 @@ const getBookingDataFromStorage = () => {
 // Helper function to transform API booking data
 
 const transformApiBookingData = (apiData: ApiBooking): Booking => {
-  return transformBookingResponse(apiData);
+  return apiData;
 };
 
 // Helper function to transform localStorage booking data
@@ -83,7 +83,7 @@ const transformLocalStorageBookingData = (
   const bookingResult: ApiBooking =
     savedBookingData.bookingResult ?? (savedBookingData as unknown as ApiBooking);
 
-  return transformBookingResponse(bookingResult);
+  return bookingResult;
 };
 
 // Helper component for loading state
@@ -183,30 +183,30 @@ const BookingSuccessContent: React.FC<BookingSuccessContentProps> = ({
             </div>
             <div>
               <p className="text-sm text-gray-500">Trạng thái</p>
-              <p className="font-semibold capitalize text-green-600">{booking.booking_status}</p>
+              <p className="font-semibold capitalize text-green-600">{booking.status}</p>
             </div>
             <div>
               <p className="text-sm text-gray-500">Ghế ngồi</p>
 
-              <p className="font-semibold">{booking.booking_seats?.map((bs: BookingSeatRelation) => bs.seat?.name).join(", ") || "N/A"}</p>
+              <p className="font-semibold">{booking.seats?.map((s) => s.name).join(", ") || "N/A"}</p>
             </div>
             <div>
               <p className="text-sm text-gray-500">Tổng tiền</p>
-              <p className="font-semibold text-red-600">{booking.total_price?.toLocaleString("vi-VN") || "0"} VNĐ</p>
+              <p className="font-semibold text-red-600">{booking.totalPrice?.toLocaleString("vi-VN") || "0"} VNĐ</p>
             </div>
             <div>
               <p className="text-sm text-gray-500">Phương thức thanh toán</p>
-              <p className="font-semibold capitalize">{booking.payment_method}</p>
+              <p className="font-semibold capitalize">{booking.paymentMethod}</p>
             </div>
             <div>
               <p className="text-sm text-gray-500">Thời gian đặt</p>
-              <p className="font-semibold">{booking.booking_date_time ? new Date(booking.booking_date_time).toLocaleString("vi-VN") : "N/A"}</p>
+              <p className="font-semibold">{booking.bookingDate ? new Date(booking.bookingDate).toLocaleString("vi-VN") : "N/A"}</p>
             </div>
           </div>
         </div>
 
         {/* Movie & Showtime Info */}
-        {booking.showtime && (
+        {booking.showTime && (
           <div className="mb-6 rounded-lg border p-6">
             <h2 className="mb-4 text-xl font-semibold">Thông tin phim & suất chiếu</h2>
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -221,7 +221,7 @@ const BookingSuccessContent: React.FC<BookingSuccessContentProps> = ({
               <div>
                 <p className="text-sm text-gray-500">Thời gian chiếu</p>
                 <p className="font-semibold">
-                  {booking.showtime.show_date_time ? new Date(booking.showtime.show_date_time).toLocaleString("vi-VN") : "N/A"}
+                  {booking.showTime?.showDateTime ? new Date(booking.showTime.showDateTime).toLocaleString("vi-VN") : "N/A"}
                 </p>
               </div>
               <div>
@@ -238,7 +238,7 @@ const BookingSuccessContent: React.FC<BookingSuccessContentProps> = ({
           <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
             <div>
               <p className="text-sm text-gray-500">Họ và tên</p>
-              <p className="font-semibold">{booking.user?.full_name || "N/A"}</p>
+              <p className="font-semibold">{booking.user?.fullName || "N/A"}</p>
             </div>
             <div>
               <p className="text-sm text-gray-500">Số điện thoại</p>
@@ -252,13 +252,13 @@ const BookingSuccessContent: React.FC<BookingSuccessContentProps> = ({
         </div>
 
         {/* Combos and Snacks */}
-        {((booking.booking_combos && booking.booking_combos.length > 0) || (booking.booking_snacks && booking.booking_snacks.length > 0)) && (
+        {((booking.bookingCombos && booking.bookingCombos.length > 0) || (booking.bookingSnacks && booking.bookingSnacks.length > 0)) && (
           <div className="mb-6 rounded-lg border p-6">
             <h2 className="mb-4 text-xl font-semibold">Đồ ăn & Thức uống</h2>
 
             {/* Combos */}
 
-            {booking.booking_combos?.map((bookingCombo: BookingComboRelation, index: number) => {
+            {booking.bookingCombos?.map((bookingCombo, index) => {
               // Calculate combo price from snacks
               const comboPrice = bookingCombo.combo?.snacks?.reduce((total: number, snack: { price?: number }) => total + (snack.price || 0), 0) || 0;
               const totalPrice = comboPrice * (bookingCombo.quantity || 1);
@@ -274,18 +274,18 @@ const BookingSuccessContent: React.FC<BookingSuccessContentProps> = ({
 
             {/* Individual Snacks */}
 
-            {booking.booking_snacks?.map((bookingSnack: BookingSnackRelation, index: number) => (
+            {booking.bookingSnacks?.map((bookingSnack, index) => (
               <div key={`snack-${index}`} className="flex items-center justify-between py-2">
                 <span>{bookingSnack.snack?.name || "Snack"}</span>
                 <span>x{bookingSnack.quantity}</span>
-                <span className="font-semibold">{((bookingSnack.snack?.price || 0) * bookingSnack.quantity).toLocaleString("vi-VN")} VNĐ</span>
+                <span className="font-semibold">{((bookingSnack.snack?.price || 0) * (bookingSnack.quantity ?? 0)).toLocaleString("vi-VN")} VNĐ</span>
               </div>
             ))}
           </div>
         )}
 
         {/* Promotion & Loyalty Info */}
-        {(!!booking.promotion || (!!booking.loyalty_point_used && booking.loyalty_point_used > 0)) && (
+        {(!!booking.promotion || (!!booking.loyaltyPointsUsed && booking.loyaltyPointsUsed > 0)) && (
           <div className="mb-6 rounded-lg border p-6">
             <h2 className="mb-4 text-xl font-semibold">Khuyến mãi & Điểm thưởng</h2>
             <div className="space-y-4">
@@ -293,15 +293,15 @@ const BookingSuccessContent: React.FC<BookingSuccessContentProps> = ({
                 <div>
                   <p className="text-sm text-gray-500">Khuyến mãi áp dụng</p>
                   <p className="font-semibold text-green-600">{booking.promotion.title || "Khuyến mãi"}</p>
-                  {!!(booking.promotion.discount_value && booking.promotion.discount_value > 0) && (
-                    <p className="text-sm text-gray-600">Giảm {booking.promotion.discount_value.toLocaleString("vi-VN")} VNĐ</p>
+                  {!!(booking.promotion.discountValue && booking.promotion.discountValue > 0) && (
+                    <p className="text-sm text-gray-600">Giảm {booking.promotion.discountValue.toLocaleString("vi-VN")} VNĐ</p>
                   )}
                 </div>
               )}
-              {!!(booking.loyalty_point_used && booking.loyalty_point_used > 0) && (
+              {!!(booking.loyaltyPointsUsed && booking.loyaltyPointsUsed > 0) && (
                 <div>
                   <p className="text-sm text-gray-500">Điểm thưởng sử dụng</p>
-                  <p className="font-semibold text-blue-600">{booking.loyalty_point_used.toLocaleString("vi-VN")} điểm</p>
+                  <p className="font-semibold text-blue-600">{booking.loyaltyPointsUsed.toLocaleString("vi-VN")} điểm</p>
                 </div>
               )}
             </div>
@@ -378,8 +378,8 @@ const BookingSuccessPage: React.FC = () => {
   }, [bookingData, savedBookingData, isLoading]);
 
   // Fetch additional data based on booking showtime
-  const movieId = booking?.showtime?.movie_id || 0;
-  const roomId = booking?.showtime?.room_id || 0;
+  const movieId = booking?.showTime?.movieId || 0;
+  const roomId = booking?.showTime?.roomId || 0;
 
   const { data: movieData } = queryMovie(movieId);
   const { data: cinemaRoomData } = useCinemaRoom(roomId);
@@ -413,13 +413,6 @@ const BookingSuccessPage: React.FC = () => {
       };
     }
 
-    // Fallback to showtime room info
-    if (booking?.showtime?.cinema_room?.room_number) {
-      return {
-        room_number: booking.showtime.cinema_room.room_number,
-      };
-    }
-
     // Fallback to localStorage cinema name
     if (savedBookingData?.cinemaName) {
       return {
@@ -430,7 +423,7 @@ const BookingSuccessPage: React.FC = () => {
     return {
       room_number: `${roomId}` || "N/A",
     };
-  }, [cinemaRoomData, booking?.showtime, roomId, savedBookingData]);
+  }, [cinemaRoomData, booking?.showTime, roomId, savedBookingData]);
 
   // Show loading state - only show if we have a valid booking ID and are still loading
   if (isLoading && bookingIdNumber && !booking) {

--- a/apps/fe-react-app/src/feature/booking/components/PaymentInfo/PaymentInfo.tsx
+++ b/apps/fe-react-app/src/feature/booking/components/PaymentInfo/PaymentInfo.tsx
@@ -37,11 +37,11 @@ const PaymentInfo: React.FC<PaymentInfoProps> = ({ user, selectedSeats = [] }) =
   };
 
   return (
-    <div className="space-y-4">
+  <div className="space-y-4">
       <h3 className="border-l-4 border-red-600 pl-3 text-lg font-bold">THÔNG TIN THANH TOÁN</h3>
       <div className="grid grid-cols-1 gap-4 text-sm md:grid-cols-3">
         <div>
-          <span className="font-semibold">Họ tên:</span> {user.full_name}
+          <span className="font-semibold">Họ tên:</span> {user.fullName}
         </div>
         <div>
           <span className="font-semibold">Số điện thoại:</span> {user.phone}

--- a/apps/fe-react-app/src/feature/userprofile/components/MovieHistory.tsx
+++ b/apps/fe-react-app/src/feature/userprofile/components/MovieHistory.tsx
@@ -6,7 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/Shadcn/ui/table";
 import { useAuth } from "@/hooks/useAuth";
 import type { components } from "@/schema-from-be";
-import { queryBookingsByUserId, transformBookingResponse } from "@/services/bookingService";
+import { queryBookingsByUserId } from "@/services/bookingService";
 import { useCinemaRooms } from "@/services/cinemaRoomService";
 import { queryMovies } from "@/services/movieService";
 import { getUserIdFromCookie } from "@/utils/auth.utils";
@@ -139,20 +139,14 @@ export const MovieHistory: React.FC = () => {
       .filter((booking: BookingResponse) => {
         // Filter by status if not "ALL"
         if (statusFilter !== "ALL") {
-          const transformedBooking = transformBookingResponse(booking);
-          const status = transformedBooking.booking_status || "PENDING";
+          const status = booking.status || "PENDING";
           if (status !== statusFilter) return false;
         }
         return true;
       })
       .map((booking: BookingResponse) => {
-        const transformedBooking = transformBookingResponse(booking);
-
         // Resolve show time as Date for sorting and display
         const showDateTime = (() => {
-          if (transformedBooking.showtime?.show_date_time) {
-            return transformedBooking.showtime.show_date_time;
-          }
           if (booking.showTime?.showDateTime) {
             return new Date(booking.showTime.showDateTime);
           }
@@ -175,16 +169,16 @@ export const MovieHistory: React.FC = () => {
         }
 
         return {
-          id: transformedBooking.id.toString(),
-          receiptId: `HD${transformedBooking.id.toString().padStart(3, "0")}`,
+          id: String(booking.id),
+          receiptId: `HD${String(booking.id).padStart(3, "0")}`,
           movieName,
           room: roomName,
           movieSlot: showDateTime.toLocaleString("vi-VN"),
           movieTime: showDateTime,
-          seats: transformedBooking.booking_seats?.map((seatRelation) => seatRelation.seat?.name).filter(Boolean) || [],
-          points: transformedBooking.loyalty_point_used || 0,
+          seats: booking.seats?.map((seat) => seat.name).filter(Boolean) || [],
+          points: booking.loyaltyPointsUsed || 0,
           poster: movie?.poster || "https://via.placeholder.com/100x150",
-          status: transformedBooking.booking_status || "PENDING",
+          status: booking.status || "PENDING",
         };
       })
       .sort((a, b) => b.movieTime.getTime() - a.movieTime.getTime());

--- a/apps/fe-react-app/src/interfaces/booking.interface.ts
+++ b/apps/fe-react-app/src/interfaces/booking.interface.ts
@@ -10,52 +10,19 @@ export type BookingSeatTypeEnum = "COUPLE" | "PATH" | "REGULAR" | "VIP";
 export type SeatTypeName = "SINGLE" | "DOUBLE" | "PATH" | "VIP";
 
 // User interface (simplified for booking)
-export interface BookingUser {
-  id: string;
-  full_name: string;
-  email: string;
-  phone: string;
-  loyalty_point: number;
-}
+export type BookingUser = components["schemas"]["UserResponse"];
 
 // Movie interface (simplified for booking)
-export interface BookingMovie {
-  id: number;
-  name: string;
-  poster: string;
-  duration: number;
-  age_restrict: number;
-  type: string;
-  version: string;
-}
+export type BookingMovie = components["schemas"]["MovieResponse"];
 
 // Cinema Room interface (simplified for booking)
-export interface BookingCinemaRoom {
-  id: number;
-  room_number: number;
-  type: string;
-  capacity: number;
-}
+export type BookingCinemaRoom = components["schemas"]["CinemaRoomResponse"];
 
 // Showtime interface
-export interface BookingShowtime {
-  id: number;
-  room_id: number;
-  movie_id: number;
-  show_date_time: Date;
-  end_date_time: Date;
-  status: "CANCELLED" | "COMPLETED" | "ONSCREEN" | "SCHEDULE";
-  // Populated fields
-  movie?: BookingMovie;
-  cinema_room?: BookingCinemaRoom;
-}
+export type BookingShowtime = components["schemas"]["ShowtimeResponse"];
 
 // Seat Type interface
-export interface BookingSeatType {
-  id: number;
-  price: number;
-  name: SeatTypeName;
-}
+export type BookingSeatType = components["schemas"]["SeatTypeResponse"];
 
 // Seat interface for booking
 export interface BookingSeat {
@@ -76,42 +43,13 @@ export interface BookingSeat {
 }
 
 // Promotion interface
-export interface BookingPromotion {
-  id: number;
-  title: string;
-  description: string;
-  discount_value: number;
-  min_purchase: number;
-  start_time: Date;
-  end_time: Date;
-  status: number; // tinyint
-  type: number; // tinyint
-  image: string;
-}
+export type BookingPromotion = components["schemas"]["PromotionResponse"];
 
 // Snack interface
-export interface BookingSnack {
-  id: number;
-  name: string;
-  description: string;
-  price: number;
-  category: "DRINK" | "FOOD";
-  size: "SMALL" | "MEDIUM" | "LARGE";
-  flavor: string;
-  img: string;
-  status: "AVAILABLE" | "SOLD_OUT" | "UNAVAILABLE";
-}
+export type BookingSnack = components["schemas"]["SnackResponse"];
 
 // Combo interface
-export interface BookingCombo {
-  id: number;
-  name: string;
-  description: string;
-  img: string;
-  status: "AVAILABLE" | "SOLD_OUT" | "UNAVAILABLE";
-  snacks?: BookingSnack[]; // From combo_snack relationship
-  total_price?: number; // Calculated from snacks
-}
+export type BookingCombo = components["schemas"]["ComboResponse"];
 
 // Booking Seat relation
 export interface BookingSeatRelation {
@@ -143,59 +81,12 @@ export interface BookingComboRelation {
 }
 
 // Main Booking interface
-export interface Booking {
-  id: number;
-  user_id?: string;
-  booking_date_time?: Date;
-  showtime_id?: number;
-  promotion_id?: number;
-  loyalty_point_used?: number;
-  total_price?: number;
-  payment_method?: PaymentMethod;
-  payment_status?: PaymentStatus;
-  booking_status?: BookingStatus;
-  pay_os_code?: string;
-  staff_id?: string;
-
-  // Populated relationships
-  user?: BookingUser;
-  showtime?: BookingShowtime;
-  promotion?: BookingPromotion;
-  booking_seats?: BookingSeatRelation[];
-  booking_snacks?: BookingSnackRelation[];
-  booking_combos?: BookingComboRelation[];
-}
+export type Booking = components["schemas"]["BookingResponse"];
 
 // Request interfaces for API
-export interface BookingRequest {
-  user_id?: string;
-  showtime_id: number;
-  promotion_id?: number;
-  loyalty_point_used?: number;
-  payment_method: PaymentMethod;
-  staff_id?: string;
-  // Seat IDs to book
-  seat_ids: number[];
-  // Snacks to book
-  snacks?: Array<{
-    snack_id: number;
-    quantity: number;
-  }>;
-  // Combos to book
-  combos?: Array<{
-    combo_id: number;
-    quantity: number;
-  }>;
-}
+export type BookingRequest = components["schemas"]["BookingRequest"];
 
-export interface BookingUpdateRequest {
-  promotion_id?: number;
-  loyalty_point_used?: number;
-  payment_method?: PaymentMethod;
-  payment_status?: PaymentStatus;
-  booking_status?: BookingStatus;
-  pay_os_code?: string;
-}
+export type BookingUpdateRequest = components["schemas"]["BookingUpdate"];
 
 // UI-specific interfaces for booking process
 export interface BookingState {

--- a/apps/fe-react-app/src/services/bookingService.ts
+++ b/apps/fe-react-app/src/services/bookingService.ts
@@ -172,158 +172,7 @@ export const useBookedSeatsByShowtime = (showtimeId: number) => {
  * Transform API BookingResponse to internal Booking interface
  */
 export const transformBookingResponse = (bookingResponse: BookingResponse): Booking => {
-  // Helper functions for status mapping
-  const mapPaymentStatus = (status?: string) => {
-    if (status === "SUCCESS") return "SUCCESS";
-    if (status === "FAILED") return "FAILED";
-    return "PENDING";
-  };
-
-  const mapBookingStatus = (status?: string) => {
-    if (status === "SUCCESS") return "SUCCESS";
-    if (status === "CANCELLED") return "CANCELLED";
-    return "PENDING";
-  };
-
-  const mapSeatTypeName = (name?: string) => {
-    if (name === "VIP") return "VIP";
-    if (name === "COUPLE") return "DOUBLE";
-    if (name === "PATH") return "PATH";
-    return "SINGLE"; // Default for REGULAR and BLOCK
-  };
-
-  const mapShowtimeStatus = (status?: string) => {
-    if (status === "CANCELLED") return "CANCELLED";
-    if (status === "COMPLETED") return "COMPLETED";
-    if (status === "ONSCREEN") return "ONSCREEN";
-    return "SCHEDULE";
-  };
-
-  return {
-    id: bookingResponse.id || 0,
-    user_id: bookingResponse.user?.id || "",
-    user: bookingResponse.user
-      ? {
-          id: bookingResponse.user.id || "",
-          full_name: bookingResponse.user.fullName || "",
-          email: bookingResponse.user.email || "",
-          phone: bookingResponse.user.phone || "",
-          loyalty_point: bookingResponse.loyaltyPointsUsed || 0,
-        }
-      : undefined,
-    showtime_id: bookingResponse.showTime?.id || 0,
-    showtime: bookingResponse.showTime
-      ? {
-          id: bookingResponse.showTime.id || 0,
-          room_id: bookingResponse.showTime.roomId || 0,
-          movie_id: bookingResponse.showTime.movieId || 0,
-          show_date_time: new Date(bookingResponse.showTime.showDateTime || new Date()),
-          end_date_time: new Date(bookingResponse.showTime.endDateTime || new Date()),
-          status: mapShowtimeStatus(bookingResponse.showTime.status),
-        }
-      : undefined,
-    promotion_id: bookingResponse.promotion?.id || undefined,
-    promotion: bookingResponse.promotion
-      ? {
-          id: bookingResponse.promotion.id || 0,
-          title: bookingResponse.promotion.title || "",
-          description: bookingResponse.promotion.description || "",
-          discount_value: bookingResponse.promotion.discountValue || 0,
-          min_purchase: bookingResponse.promotion.minPurchase || 0,
-          start_time: new Date(bookingResponse.promotion.startTime || new Date()),
-          end_time: new Date(bookingResponse.promotion.endTime || new Date()),
-          status: 1, // Convert to number
-          type: 1, // Convert to number
-          image: bookingResponse.promotion.image || "",
-        }
-      : undefined,
-    booking_date_time: new Date(bookingResponse.bookingDate || new Date()),
-    total_price: bookingResponse.totalPrice || 0,
-    payment_method: bookingResponse.paymentMethod === "CASH" ? "CASH" : "ONLINE",
-    payment_status: mapPaymentStatus(bookingResponse.paymentStatus),
-    booking_status: mapBookingStatus(bookingResponse.status),
-    staff_id: bookingResponse.staffId || undefined,
-    pay_os_code: bookingResponse.payOsCode || undefined,
-    loyalty_point_used: bookingResponse.loyaltyPointsUsed && bookingResponse.loyaltyPointsUsed > 0 ? bookingResponse.loyaltyPointsUsed : undefined,
-
-    // Transform seats - using booking_seats relation format
-    booking_seats:
-      bookingResponse.seats?.map((seat, index) => ({
-        id: index + 1, // Generate relation ID
-        seat_id: seat.id || 0,
-        booking_id: bookingResponse.id || 0,
-        seat: {
-          id: seat.id || 0,
-          name: seat.name || "",
-          seat_type_id: seat.type?.id || 0,
-          seat_column: seat.column || "",
-          seat_row: seat.row || "",
-          status: "AVAILABLE", // Default status
-          type: "REGULAR", // Default type
-          cinema_room_id: seat.roomId || 0,
-          seat_link_id: seat.linkSeatId,
-          seat_type: seat.type
-            ? {
-                id: seat.type.id || 0,
-                price: seat.type.price || 0,
-                name: mapSeatTypeName(seat.type.name),
-              }
-            : undefined,
-        },
-      })) || [],
-
-    // Transform booking combos
-    booking_combos:
-      bookingResponse.bookingCombos?.map((comboResponse, index) => ({
-        id: index + 1, // Generate relation ID
-        booking_id: bookingResponse.id || 0,
-        combo_id: comboResponse.combo?.id || 0,
-        quantity: comboResponse.quantity || 0,
-        combo: comboResponse.combo
-          ? {
-              id: comboResponse.combo.id || 0,
-              name: comboResponse.combo.name || "",
-              description: comboResponse.combo.description || "",
-              img: comboResponse.combo.img || "",
-              status: "AVAILABLE", // Default status
-              snacks:
-                comboResponse.combo.snacks?.map((snack) => ({
-                  id: snack.id || 0,
-                  name: snack.name || "",
-                  description: snack.description || "",
-                  price: snack.price || 0,
-                  category: "FOOD", // Default category
-                  size: "MEDIUM", // Default size
-                  flavor: snack.flavor || "",
-                  img: snack.img || "",
-                  status: "AVAILABLE", // Default status
-                })) || [],
-            }
-          : undefined,
-      })) || [],
-
-    // Transform booking snacks
-    booking_snacks:
-      bookingResponse.bookingSnacks?.map((snackResponse, index) => ({
-        id: index + 1, // Generate relation ID
-        booking_id: bookingResponse.id || 0,
-        snack_id: snackResponse.snack?.id || 0,
-        quantity: snackResponse.quantity || 0,
-        snack: snackResponse.snack
-          ? {
-              id: snackResponse.snack.id || 0,
-              name: snackResponse.snack.name || "",
-              description: snackResponse.snack.description || "",
-              price: snackResponse.snack.price || 0,
-              category: "FOOD", // Default category
-              size: "MEDIUM", // Default size
-              flavor: snackResponse.snack.flavor || "",
-              img: snackResponse.snack.img || "",
-              status: "AVAILABLE", // Default status
-            }
-          : undefined,
-      })) || [],
-  };
+  return bookingResponse;
 };
 
 /**
@@ -332,24 +181,24 @@ export const transformBookingResponse = (bookingResponse: BookingResponse): Book
 export const transformBookingToRequest = (booking: Partial<Booking>): BookingRequest => {
   const { origin } = window.location;
   return {
-    userId: booking.user_id || "",
-    showtimeId: booking.showtime_id || 0,
-    promotionId: booking.promotion_id || undefined,
-    seatIds: booking.booking_seats?.map((relation) => relation.seat_id) || [],
-    totalPrice: booking.total_price,
-    paymentMethod: booking.payment_method === "CASH" ? "CASH" : "ONLINE",
-    staffId: booking.staff_id || undefined,
-    estimatedPrice: booking.total_price || 0,
-    loyaltyPointsUsed: booking.loyalty_point_used || undefined,
+    userId: booking.user?.id || "",
+    showtimeId: booking.showTime?.id || 0,
+    promotionId: booking.promotion?.id || undefined,
+    seatIds: booking.seats?.map((seat) => seat.id || 0) || [],
+    totalPrice: booking.totalPrice,
+    paymentMethod: booking.paymentMethod === "CASH" ? "CASH" : "ONLINE",
+    staffId: booking.staffId || undefined,
+    estimatedPrice: booking.totalPrice || 0,
+    loyaltyPointsUsed: booking.loyaltyPointsUsed || undefined,
     bookingCombos:
-      booking.booking_combos?.map((relation) => ({
-        comboId: relation.combo_id,
-        quantity: relation.quantity,
+      booking.bookingCombos?.map((relation) => ({
+        comboId: relation.combo?.id || 0,
+        quantity: relation.quantity || 0,
       })) || undefined,
     bookingSnacks:
-      booking.booking_snacks?.map((relation) => ({
-        snackId: relation.snack_id,
-        quantity: relation.quantity,
+      booking.bookingSnacks?.map((relation) => ({
+        snackId: relation.snack?.id || 0,
+        quantity: relation.quantity || 0,
       })) || undefined,
     feUrl: origin,
   };


### PR DESCRIPTION
## Summary
- map booking interfaces to types generated from the OpenAPI schema
- update booking utilities and pages for new camelCase fields
- build `fe-react-app` to verify refactor

## Testing
- `pnpm --filter fe-react-app build`

------
https://chatgpt.com/codex/tasks/task_e_687db70e86288331bfd296d96180e834