### PR TITLE
Implement room-based timeline refresh

### DIFF
--- a/apps/fe-react-app/src/feature/manager/show-time/ShowtimeForm.tsx
+++ b/apps/fe-react-app/src/feature/manager/show-time/ShowtimeForm.tsx
@@ -67,8 +67,8 @@ export function ShowtimeForm({ initialData, onSuccess, onCancel }: ShowtimeFormP
     defaultValues: {
       movieId: initialData?.movieId.toString() || "",
       roomId: initialData?.roomId?.toString() || "",
-      showDate: initialData ? new Date(initialData.showDateTime) : new Date(),
-      startTime: initialData ? formatTimeForInput(new Date(initialData.showDateTime)) : "0",
+      showDate: initialData ? new Date(initialData.showDateTime) : undefined,
+      startTime: initialData ? formatTimeForInput(new Date(initialData.showDateTime)) : "",
       endTime: initialData ? formatTimeForInput(new Date(initialData.endDateTime)) : "",
       manualEndTime: Boolean(initialData),
     },
@@ -286,6 +286,13 @@ export function ShowtimeForm({ initialData, onSuccess, onCancel }: ShowtimeFormP
               />
             </div>
 
+            <ShowtimeTimeline
+              roomId={roomId}
+              selectedDate={showDate}
+              movies={movies}
+              selectedMovieId={movieId}
+            />
+
             {/* Date Picker using Calendar like Register.tsx */}
             <FormField
               control={form.control}
@@ -322,8 +329,6 @@ export function ShowtimeForm({ initialData, onSuccess, onCancel }: ShowtimeFormP
                 </FormItem>
               )}
             />
-
-            <ShowtimeTimeline roomId={roomId} selectedDate={showDate} movies={movies} selectedMovieId={movieId} />
 
             {/* Time Pickers using Input type="time" */}
             <div className="grid grid-cols-1 gap-6 md:grid-cols-2">

--- a/apps/fe-react-app/src/services/showtimeService.ts
+++ b/apps/fe-react-app/src/services/showtimeService.ts
@@ -20,9 +20,13 @@ export const queryShowtimesByMovie = (movieId: number) => {
   });
 };
 
-export const queryShowtimesByRoom = (roomId: number) => {
+export const queryShowtimesByRoom = (
+  roomId: number,
+  options?: Record<string, unknown>,
+) => {
   return $api.useQuery("get", "/showtimes/room/{roomId}", {
     params: { path: { roomId } },
+    ...(options ?? {}),
   });
 };
 


### PR DESCRIPTION
## Summary
- update `queryShowtimesByRoom` to accept query options
- show timeline right after selecting room in `ShowtimeForm`
- require user to pick a show date instead of using today's default
- require explicit start time instead of using placeholder value

## Testing
- `pnpm exec nx run @fcinema-workspace/fe-react-app:typecheck --skip-nx-cache`
- `pnpm exec nx run @fcinema-workspace/fe-react-app:build --skip-nx-cache`
- `pnpm exec nx run @fcinema-workspace/fe-react-app:lint --skip-nx-cache`


------
https://chatgpt.com/codex/tasks/task_e_688714c48658833196d782f9bae8917a