### PR TITLE
Update showtime form layout and timeline display

### DIFF
--- a/apps/fe-react-app/src/feature/manager/show-time/ShowtimeForm.tsx
+++ b/apps/fe-react-app/src/feature/manager/show-time/ShowtimeForm.tsx
@@ -340,6 +340,7 @@ export function ShowtimeForm({ initialData, onSuccess, onCancel }: ShowtimeFormP
               selectedDate={showDate}
               movies={movies}
               selectedMovieId={movieId}
+              roomName={rooms.find((r) => r.id?.toString() === roomId)?.name}
             />
 
             {/* Time Pickers using Input type="time" */}

--- a/apps/fe-react-app/src/feature/manager/show-time/ShowtimeTimeline.tsx
+++ b/apps/fe-react-app/src/feature/manager/show-time/ShowtimeTimeline.tsx
@@ -11,49 +11,46 @@ interface ShowtimeTimelineProps {
   readonly selectedDate?: Date;
   readonly movies: Movie[];
   readonly selectedMovieId?: string;
+  readonly roomName?: string;
 }
 
-export function ShowtimeTimeline({ roomId, selectedDate, movies, selectedMovieId }: ShowtimeTimelineProps) {
+export function ShowtimeTimeline({ roomId, selectedDate, movies, selectedMovieId, roomName }: ShowtimeTimelineProps) {
   const { data, isLoading } = queryShowtimesByRoom(Number(roomId ?? 0), {
     enabled: !!roomId,
   });
 
   const showtimes = useMemo(() => {
-    if (!data?.result) return [];
+    if (!data?.result || !selectedDate) return [];
     const all = transformShowtimesResponse(data.result);
-    if (!selectedDate) return all;
     const dateStr = selectedDate.toISOString().split("T")[0];
     return all.filter((st) => st.showDateTime.split("T")[0] === dateStr);
   }, [data?.result, selectedDate]);
 
   const getMovieName = (id: number) => movies.find((m) => m.id === id)?.name || `Movie ${id}`;
 
-  if (!roomId) return null;
+  if (!roomId || !selectedDate) return null;
 
   if (isLoading) return <LoadingSpinner />;
 
+  const header =
+    selectedDate && roomName ? `Lịch chiếu trong ngày ${format(selectedDate, "dd/MM/yyyy")} của phòng chiếu ${roomName}` : "Lịch chiếu trong ngày";
+
   return (
     <div className="space-y-2">
-      <h4 className="font-semibold">Lịch chiếu trong ngày</h4>
+      <h4 className="font-semibold">{header}</h4>
       {showtimes.length === 0 ? (
         <p className="text-muted-foreground text-sm">Không có lịch chiếu</p>
       ) : (
         <ul className="space-y-2 text-sm">
           {showtimes.map((st) => (
-            <li
-              key={st.id}
-              className="flex items-center justify-between rounded-md border p-2"
-            >
+            <li key={st.id} className="flex items-center justify-between rounded-md border p-2">
               <div className={st.movieId.toString() === selectedMovieId ? "font-medium" : ""}>
                 <p>{getMovieName(st.movieId)}</p>
                 <p className="text-muted-foreground text-xs">
                   {format(new Date(st.showDateTime), "dd/MM/yyyy HH:mm")} - {format(new Date(st.endDateTime), "HH:mm")}
                 </p>
               </div>
-              <Badge
-                variant="outline"
-                className={getShowtimeStatusColor(st.status)}
-              >
+              <Badge variant="outline" className={getShowtimeStatusColor(st.status)}>
                 {st.status}
               </Badge>
             </li>


### PR DESCRIPTION
## Summary
- reset movie and date fields when the cinema room changes
- place room, movie and date fields in a single row
- show showtime status and timing information using ShadCN components

## Testing
- `pnpm exec nx run @fcinema-workspace/fe-react-app:typecheck --disableNxCache --disableRemoteCache --verbose --outputStyle=static`
- `pnpm exec nx run @fcinema-workspace/fe-react-app:build --disableNxCache --disableRemoteCache --verbose --outputStyle=static`
- `pnpm exec nx run @fcinema-workspace/fe-react-app:lint --disableNxCache --disableRemoteCache --verbose --outputStyle=static`


------
https://chatgpt.com/codex/tasks/task_e_688731cd2d0483318f51a4c4247d626a