### PR TITLE
Fix showtime query refetch

### DIFF
--- a/apps/fe-react-app/src/feature/manager/show-time/ShowtimeTimeline.tsx
+++ b/apps/fe-react-app/src/feature/manager/show-time/ShowtimeTimeline.tsx
@@ -15,8 +15,10 @@ interface ShowtimeTimelineProps {
 }
 
 export function ShowtimeTimeline({ roomId, selectedDate, movies, selectedMovieId, roomName }: ShowtimeTimelineProps) {
-  const { data, isLoading } = queryShowtimesByRoom(Number(roomId ?? 0), {
-    enabled: !!roomId,
+  const numericRoomId = Number(roomId ?? 0);
+  const shouldFetch = numericRoomId > 0;
+  const { data, isLoading } = queryShowtimesByRoom(numericRoomId, {
+    enabled: shouldFetch,
   });
 
   const showtimes = useMemo(() => {
@@ -28,7 +30,7 @@ export function ShowtimeTimeline({ roomId, selectedDate, movies, selectedMovieId
 
   const getMovieName = (id: number) => movies.find((m) => m.id === id)?.name || `Movie ${id}`;
 
-  if (!roomId || !selectedDate) return null;
+  if (!shouldFetch || !selectedDate) return null;
 
   if (isLoading) return <LoadingSpinner />;
 


### PR DESCRIPTION
## Summary
- adjust `ShowtimeTimeline` to disable fetching when roomId is invalid

## Testing
- `pnpm exec nx run @fcinema-workspace/fe-react-app:typecheck --disableNxCache --disableRemoteCache --verbose --outputStyle=static`
- `pnpm exec nx run @fcinema-workspace/fe-react-app:build --disableNxCache --disableRemoteCache --verbose --outputStyle=static`
- `pnpm exec nx run @fcinema-workspace/fe-react-app:lint --disableNxCache --disableRemoteCache --verbose --outputStyle=static`


------
https://chatgpt.com/codex/tasks/task_e_6889dfe498f483319ed3853564ea58cb